### PR TITLE
Redid Base.yml while also making slimepeople unable to rot again.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -23,6 +23,7 @@
     - FootstepSound
     - DoorBumpOpener
     - SpiderCraft
+  - type: Perishable
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -287,7 +287,6 @@
     shiveringHeatRegulation: 2000
     normalBodyTemperature: 310.15
     thermalRegulationTemperatureThreshold: 25
-  - type: Perishable
   - type: Butcherable
     butcheringType: Spike # TODO human.
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
@@ -21,6 +21,7 @@
       Brute:
         sprite: Mobs/Effects/brute_damage.rsi
         color: "#896e55"
+  - type: Perishable
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -10,6 +10,7 @@
     sprite: Mobs/Species/Human/parts.rsi
     state: full
   - type: Thirst
+  - type: Perishable
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -24,6 +24,7 @@
     speechVerb: Moth
   - type: TypingIndicator
     proto: moth
+  - type: Perishable
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -17,6 +17,7 @@
   - type: Body
     prototype: Reptilian
     requiredLegs: 2
+  - type: Perishable
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -26,6 +26,7 @@
       Male: UnisexVox
       Female: UnisexVox
       Unsexed: UnisexVox
+  - type: Perishable
   - type: Butcherable
     butcheringType: Spike
     spawned:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Slimepeople rot now, which is disappointing. This aims to revert that change. I also redid Base.yml to move the "perishable" type to species files.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. --> Slimepeople used to not rot, which is the only major advantage slimes have over other races. Now that slimes rot, that advantage has been lost, and Slimepeople became worse. This aims to bring that advantage back.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. --> I moved the "`- type: Perishable`" stuff from the Base.yml to the species. This allows only certain species with that type to rot.

Diona do not need the `"- type: Perishable"`, because they disintegrate upon dying, which makes rotting irrelevant.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- tweak: Slimepeople now have no `- type: Perishable`, meaning they no longer rot.
Redid Base.yml.
- tweak: Diana have no`- type: Perishable` too, but that’s because they disintegrate upon dying, making rotting pointless.
- tweak: Redid Base.yml.