### PR TITLE
Give atmos fire axe ability to pry tiles.

### DIFF
--- a/Resources/Locale/en-US/tools/tool-qualities.ftl
+++ b/Resources/Locale/en-US/tools/tool-qualities.ftl
@@ -4,6 +4,9 @@ tool-quality-anchoring-tool-name = Wrench
 tool-quality-prying-name = Prying
 tool-quality-prying-tool-name = Crowbar
 
+tool-quality-prying-name = Axing
+tool-quality-prying-tool-name = Fireaxe
+
 tool-quality-screwing-name = Screwing
 tool-quality-screwing-tool-name = Screwdriver
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -39,6 +39,7 @@
   - type: Tool
     qualities:
       - Prying
+      - Axing
   - type: ToolTileCompatible
   - type: Prying
   - type: UseDelay

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -4,6 +4,7 @@
   sprite: /Textures/Tiles/plating.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -20,6 +21,7 @@
   - 1.0
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -31,6 +33,7 @@
   sprite: /Textures/Tiles/plating_burnt.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -42,6 +45,7 @@
   sprite: /Textures/Tiles/Asteroid/asteroid_plating.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -53,6 +57,7 @@
   sprite: /Textures/Tiles/Misc/clockwork/clockwork_floor.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -64,6 +69,7 @@
   sprite: /Textures/Tiles/snow_plating.png #Not in the snow planet RSI because it doesn't have any metadata. Should probably be moved to its own folder later.
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.15 #a little less then actual snow

--- a/Resources/Prototypes/tool_qualities.yml
+++ b/Resources/Prototypes/tool_qualities.yml
@@ -6,6 +6,13 @@
   icon: { sprite: Objects/Tools/wrench.rsi, state: icon }
 
 - type: tool
+  id: Axing
+  name: tool-quality-axing-name
+  toolName: tool-quality-axing-tool-name
+  spawn: FireAxe
+  icon: { sprite: Objects/Weapons/Melee/fireaxe.rsi, state: icon }
+
+- type: tool
   id: Prying
   name: tool-quality-prying-name
   toolName: tool-quality-prying-tool-name


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Gives a new tool quality, “Axing”, applied to atmospheric fireaxes.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
right now, there was no way to pry plating tiles, so if you made a mistake of applying a plating tile to a lattice tile, you can’t reverse it without having to use a limited-charge RCD. We have determined that the best tool for the job as an atmospheric technician’s fireaxe, as it is usually only available for atmospherics engineers and not regular passengers with crowbars. If very common tools such as crowbars were able to pry plating, the station would be quickly made uninhabitatable, due to either shitters, raiders, free-agents, or antagonists prying open plating, spacing a lot of rooms.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Created “Axing” quality, and applied it to an atmospheric technician’s fireaxe.