### PR TITLE
Fix syndimothroach texture path in prototypes.

### DIFF
--- a/Resources/Prototypes/Ronstation/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Mobs/NPCs/animals.yml
@@ -31,7 +31,7 @@
     insertingState: inserting_mothroach
   - type: MothAccent
   - type: Sprite
-    sprite: Ronstation/Entities/Mobs/Animals/Pets/syndimothroach.rsi
+    sprite: Ronstation/Mobs/Animals/syndimothroach.rsi
     layers:
     - map: ["enum.DamageStateVisualLayers.Base", "movement"]
       state: syndimothroach
@@ -46,7 +46,7 @@
     size: Normal
   - type: Clothing
     quickEquip: false
-    sprite: Ronstation/Entities/Mobs/Animals/Pets/syndimothroach.rsi
+    sprite: Ronstation/Mobs/Animals/syndimothroach.rsi
     equippedPrefix: 0
     slots:
     - HEAD


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Modifies the directory path used to find syndimothroach textures to the correct configuration.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Current syndimothroach directory is incorrect, resulting in this:
<img width="663" alt="Screenshot 2024-08-01 233911" src="https://github.com/user-attachments/assets/65f42a24-3036-4e07-83f8-a3081d04a032">
This PR fixes this error.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed syndimothroach texture path in prototypes.