### PR TITLE
xeno change

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -57,10 +57,10 @@
     allowedStates:
     - Alive
     - Dead
-  - type: MobThresholds
+  - type: MobThresholds 
     thresholds:
       0: Alive
-      50: Dead
+      65: Dead  # RonStation - Xeno change
   - type: SlowOnDamage
     speedModifierThresholds:
       25: 0.5
@@ -119,6 +119,8 @@
     molsPerSecondPerUnitMass: 0.0005
   - type: Speech
     speechVerb: LargeMob
+  - type: StaticPrice # RonStation - Xeno change
+    price: 2500
 
 - type: entity
   name: Praetorian


### PR DESCRIPTION
## About the PR
a small change in xenos. they became more valuable.

## Why / Balance
a new way for salvage getting money. there's usually alot of burrowers at Mars (AKA the big distant asteroid), so i buffed their health by 15. you now require 3 shots (or 2 shots and 1 stab if you're kool enough) to kill a burrower.

## Technical details
no

## Media
- [ X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
Xenos are now more valuable.
