### PR TITLE
Goliath debuff

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -50,21 +50,21 @@
       Dead:
         Base: goliath_dead
   - type: MovementSpeedModifier
-    baseWalkSpeed : 2.50
-    baseSprintSpeed : 2.50
+    baseWalkSpeed : 2.00
+    baseSprintSpeed : 2.00
   - type: MobThresholds
     thresholds:
       0: Alive
-      300: Dead
+      250: Dead
   - type: MeleeWeapon
     soundHit:
       path: "/Audio/Weapons/smash.ogg"
     angle: 0
-    attackRate: 0.75
+    attackRate: 0.8
     animation: WeaponArcPunch
     damage:
       types:
-        Slash: 15
+        Slash: 10
         Piercing: 10
   - type: NpcFactionMember
     factions:


### PR DESCRIPTION
## About the PR
Debuffs goliath

## Why / Balance
Roundstart hardsuits for salvage already suck due to it's slow speed, and goliaths spawn in pairs or alone, hell for any lone cargo technician or salvager

## Technical details
Lowers speed, damage, attack speed and health

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->