### PR TITLE
Rework firelocks.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -95,6 +95,7 @@
       - id: GasAnalyzer
       - id: MedkitOxygenFilled
       - id: HolofanProjector
+      - id: DoorRemoteFirefight
       - id: RCD
       - id: RCDAmmo
 
@@ -112,6 +113,7 @@
       - id: GasAnalyzer
       - id: MedkitOxygenFilled
       - id: HolofanProjector
+      - id: DoorRemoteFirefight
       - id: RCD
       - id: RCDAmmo
 

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -105,6 +105,7 @@
       arc: 360
     - type: StaticPrice
       price: 150
+    - type: DoorBolt
     - type: AccessReader
       access: [ [ "Engineering" ] ]
     - type: PryUnpowered

--- a/Resources/Prototypes/Ronstation/Access/engineering.yml
+++ b/Resources/Prototypes/Ronstation/Access/engineering.yml
@@ -1,0 +1,5 @@
+- type: accessGroup
+  id: FireFight
+  tags:
+    - Atmospherics
+

--- a/Resources/Prototypes/Ronstation/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Objects/Devices/door_remote.yml
@@ -1,0 +1,17 @@
+- type: entity
+  parent: DoorRemoteDefault
+  id: DoorRemoteFirefight
+  name: fire-fighting door remote
+  description: A gadget which can open and bolt FireDoors remotely.
+  components:
+    - type: Sprite
+      layers:
+        - state: door_remotebase
+        - state: door_remotelightscolour
+          color: "#ff9900"
+        - state: door_remotescreencolour
+          color: "#e02020"
+
+    - type: Access
+      groups:
+        - FireFight

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -347,7 +347,7 @@ chem_master: ChemMaster
 CrateJanitorExplosive: ClosetJanitorBombFilled
 
 # 2024-05-27
-DoorRemoteFirefight: null
+# DoorRemoteFirefight: null
 
 # 2024-06-03
 AirlockServiceCaptainLocked: AirlockCaptainLocked


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Gives firelocks the ability to be bolted.
- Adds a fire-fighting remote inside atmospheric technician's lockers; they can only be used by atmospheric technicians.

I might add a bolt wire to firelocks soon.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Firelocks, if they're made in real-life, are supposed to be bolted upon, once it's closed after a spacing or other atmospheric issue occurs, so it can use the entire strength to prevent such issues from spreading further. Besides, it should help with not wasting so much time trying to holofan a big leak, as they expire within a short period and also their projectors have a limited charge (6 charges). On the other hand, if you weld during a tritium and plasma leak, the flame from that welder can cause the plasma or tritium within that chamber to go on fire, potentially leading to more damage.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Merrokitsune
- tweak: Gives firelocks the ability to be bolted.
- add: Adds a fire-fighting remote inside atmospheric technician's lockers; they can only be used by atmospheric technicians.
:/cl: