### PR TITLE
Demexatrine

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -147,3 +147,6 @@ reagent-desc-potassium-iodide = Will reduce the damaging effects of radiation by
 
 reagent-name-haloperidol = haloperidol
 reagent-desc-haloperidol = Removes most stimulating and hallucinogenic drugs. Reduces druggy effects and jitteriness. Causes drowsiness.
+
+reagent-name-demexatrine = demexatrine
+reagent-desc-demexatrine = A mass-produced chemical used by miners and medical personnel alike, which helps against the poison made by space wildlife. Easily overdoses and causes jittering.

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1374,4 +1374,37 @@
         amount: -3.0
       - !type:AdjustReagent
         reagent: MindbreakerToxin
-        amount: -3.0
+
+- type: reagent
+  id: Demexatrine
+  name: reagent-name-demexatrine
+  group: Medicine
+  desc: reagent-desc-demexatrine
+  physicalDesc: reagent-physical-desc-thick
+  flavor: syrupy
+  color: "#6e4665"
+  metabolisms:
+    Narcotic:
+      effects:
+      - !type:Jitter
+        min: 10
+      - !type:MovespeedModifier
+        walkSpeedModifier: 1.1
+        sprintSpeedModifier: 1.1
+    Medicine:
+      effects:
+      - !type:HealthChange
+        damage:
+          groups:
+            Airloss: -2
+            Poison: -1
+            Radiation: -0.1
+     Poison:
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 15
+        damage:
+          types:
+            Brute: 1.5
+            Piercing: 2

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1392,7 +1392,6 @@
           types:
             Asphyxiation: -2
             Poison: -1
-            Brute: -0.5
       - !type:ChemCleanBloodstream
         cleanseRate: 5
       - !type:Jitter
@@ -1403,5 +1402,4 @@
             min: 15
         damage:
           types:
-            Brute: 1.5
             Poison: 0.5

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1384,10 +1384,6 @@
   flavor: syrupy
   color: "#6e4665"
   metabolisms:
-    Narcotic:
-      effects:
-      - !type:Jitter
-        min: 10
     Medicine:
       effects:
       - !type:HealthChange
@@ -1395,11 +1391,16 @@
           types:
             Airloss: -2
             Poison: -1
-     Poison:
+            Brute: -0.5
+      - !type:ChemCleanBloodstream
+        cleanseRate: 5
+      - !type:Jitter
+        min: 10
       - !type:HealthChange
         conditions:
-        - !type:ReagentThreshold
-          min: 15
+          - !type:ReagentThreshold
+            min: 15
         damage:
           types:
             Brute: 1.5
+            Poison: 0.5

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1388,17 +1388,13 @@
       effects:
       - !type:Jitter
         min: 10
-      - !type:MovespeedModifier
-        walkSpeedModifier: 1.1
-        sprintSpeedModifier: 1.1
     Medicine:
       effects:
       - !type:HealthChange
         damage:
-          groups:
+          types:
             Airloss: -2
             Poison: -1
-            Radiation: -0.1
      Poison:
       - !type:HealthChange
         conditions:
@@ -1407,4 +1403,3 @@
         damage:
           types:
             Brute: 1.5
-            Piercing: 2

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1390,7 +1390,7 @@
       - !type:HealthChange
         damage:
           types:
-            Airloss: -2
+            Asphyxiation: -2
             Poison: -1
             Brute: -0.5
       - !type:ChemCleanBloodstream

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1395,8 +1395,6 @@
       - !type:ChemCleanBloodstream
         cleanseRate: 5
       - !type:Jitter
-        conditions:
-        min: 10
       - !type:HealthChange
         conditions:
           - !type:ReagentThreshold

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1395,6 +1395,7 @@
       - !type:ChemCleanBloodstream
         cleanseRate: 5
       - !type:Jitter
+        conditions:
         min: 10
       - !type:HealthChange
         conditions:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1374,6 +1374,7 @@
         amount: -3.0
       - !type:AdjustReagent
         reagent: MindbreakerToxin
+        amount: -3.0
 
 - type: reagent
   id: Demexatrine

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -665,12 +665,11 @@
 
 - type: reaction
   id: Demexatrine
-  impact: Medium
   minTemp: 418
   reactants:
     Epinephrine:
       amount: 1
-    Inaprovaline:
+    SulfuricAcid:
       amount: 1
     Benzene:
       amount: 1

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -674,5 +674,4 @@
     Benzene:
       amount: 1
   products:
-    Demexatrine: 2
-    Iodine: 1
+    Demexatrine: 3

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -665,6 +665,7 @@
 
 - type: reaction
   id: Demexatrine
+  impact: Medium
   minTemp: 418
   reactants:
     Epinephrine:

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -662,3 +662,17 @@
       amount: 1
   products:
     Haloperidol: 5
+
+- type: reaction
+  id: Demexatrine
+  minTemp: 418
+  reactants:
+    Epinephrine:
+      amount: 1
+    Inaprovaline:
+      amount: 1
+    Benzene:
+      amount: 1
+  products:
+    Demexatrine: 2
+    Iodine: 1


### PR DESCRIPTION
## About PR
Demexatrine, this chem will be given to salvagers as a (space) medipen for fast and accessible first aid, but will overdose if given too much of it.
## Why / Plans
Gives some purpose to Epinephrine, will be expanded on further and will be given much more usage later on.