### PR TITLE
Calomel and Ammoniated Mercury

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/chemicals.ftl
+++ b/Resources/Locale/en-US/reagents/meta/chemicals.ftl
@@ -30,3 +30,9 @@ reagent-desc-cellulose = A crystaline polydextrose polymer, plants swear by this
 
 reagent-name-rororium = rororium
 reagent-desc-rororium = A strange substance which fills the cores of the hivelords that roam the mining asteroid. Thought to be the source of their regenerative powers.
+
+reagent-name-ammoniated-mercury = ammoniated mercury
+reagent-desc-ammoniated-mercury = An inorganic compound used to treat skin problems and injuries, causes mercury poisoning if ingested in high doses.
+
+reagent-name-calomel = calomel
+reagent-desc-calomel = A mercury chloride mineral that was used as a medicine in older times, causes mercury poisoning if ingested.

--- a/Resources/Prototypes/Reagents/chemicals.yml
+++ b/Resources/Prototypes/Reagents/chemicals.yml
@@ -219,9 +219,9 @@
       - !type:HealthChange
         damage:
           groups:
-            Heat: -1.5
+            Burn: -1
       - !type:ChemCleanBloodstream
-        cleanseRate: 3.5
+        cleanseRate: 3
     Poison:
       effects:
       - !type:HealthChange

--- a/Resources/Prototypes/Reagents/chemicals.yml
+++ b/Resources/Prototypes/Reagents/chemicals.yml
@@ -201,7 +201,7 @@
       - !type:HealthChange
         damage:
           types:
-            Poison: 1.25
+            Poison: 1
             Caustic: 1
       - !type:Jitter
 
@@ -211,7 +211,7 @@
   group: Chemical
   desc: reagent-desc-ammoniated-mercury
   flavor: metallic
-  color: "white"
+  color: "#f2f0f0"
   physicalDesc: reagent-physical-desc-crystalline
   metabolisms:
     Medicine:
@@ -219,16 +219,14 @@
       - !type:HealthChange
         damage:
           groups:
-            Heat: -1.15
+            Heat: -1.5
       - !type:ChemCleanBloodstream
-        cleanseRate: 3.25
-    Poison:
-      effects:
+        cleanseRate: 3.5
      - !type:HealthChange
         conditions:
           - !type:ReagentThreshold
             min: 10
         damage:
           types:
-            Poison: 1.25
+            Poison: 1.2
       - !type:Jitter

--- a/Resources/Prototypes/Reagents/chemicals.yml
+++ b/Resources/Prototypes/Reagents/chemicals.yml
@@ -186,3 +186,49 @@
         key: Adrenaline
         component: IgnoreSlowOnDamage
         time: 120
+
+- type: reagent
+  id: Calomel
+  name: reagent-name-calomel
+  group: Chemical
+  desc: reagent-desc-calomel
+  flavor: bitter
+  color: "#6e4665"
+  physicalDesc: reagent-physical-desc-odorless
+  metabolisms:
+    Poison:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: 1.5
+            Caustic: 1
+      - !type:Jitter
+
+- type: reagent
+  id: AmmoniatedMercury
+  name: reagent-name-ammoniated-mercury
+  group: Medicine
+  desc: reagent-desc-ammoniated-mercury
+  flavor: metallic
+  color: "white"
+  physicalDesc: reagent-physical-desc-crystalline
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: -0.15
+            Caustic: -1 # ammoniated mercury is used to treat skin problems/infections; there is no virology, though
+            Heat: -1
+      - !type:ChemCleanBloodstream
+        cleanseRate: 3.75
+    Poison:
+        damage:
+          types:
+            Caustic: 0.25
+            Poison: 1
+        conditions:
+        - !type:ReagentThreshold
+          min: 10

--- a/Resources/Prototypes/Reagents/chemicals.yml
+++ b/Resources/Prototypes/Reagents/chemicals.yml
@@ -190,8 +190,8 @@
 - type: reagent
   id: Calomel
   name: reagent-name-calomel
-  group: Chemical 
   desc: reagent-desc-calomel
+  group: Chemical 
   flavor: bitter
   color: "#6e4665"
   physicalDesc: reagent-physical-desc-odorless
@@ -208,8 +208,8 @@
 - type: reagent
   id: AmmoniatedMercury
   name: reagent-name-ammoniated-mercury
-  group: Chemical
   desc: reagent-desc-ammoniated-mercury
+  group: Chemical
   flavor: metallic
   color: "#f2f0f0"
   physicalDesc: reagent-physical-desc-crystalline
@@ -222,11 +222,14 @@
             Heat: -1.5
       - !type:ChemCleanBloodstream
         cleanseRate: 3.5
-     - !type:HealthChange
+    Poison:
+      effects:
+      - !type:HealthChange
         conditions:
           - !type:ReagentThreshold
             min: 10
         damage:
           types:
-            Poison: 1.2
+            Poison: 1
+            Caustic: 2
       - !type:Jitter

--- a/Resources/Prototypes/Reagents/chemicals.yml
+++ b/Resources/Prototypes/Reagents/chemicals.yml
@@ -190,7 +190,7 @@
 - type: reagent
   id: Calomel
   name: reagent-name-calomel
-  group: Toxin 
+  group: Chemical 
   desc: reagent-desc-calomel
   flavor: bitter
   color: "#6e4665"
@@ -201,7 +201,7 @@
       - !type:HealthChange
         damage:
           types:
-            Poison: 1.5
+            Poison: 1.25
             Caustic: 1
       - !type:Jitter
 
@@ -218,17 +218,17 @@
       effects:
       - !type:HealthChange
         damage:
-          types:
-            Poison: -0.15
-            Caustic: -1 # ammoniated mercury is used to treat skin problems/infections; there is no virology, though
-            Heat: -1
+          groups:
+            Heat: -1.15
       - !type:ChemCleanBloodstream
-        cleanseRate: 3.75
+        cleanseRate: 3.25
     Poison:
+      effects:
+     - !type:HealthChange
+        conditions:
+          - !type:ReagentThreshold
+            min: 10
         damage:
           types:
-            Caustic: 0.25
-            Poison: 1
-        conditions:
-        - !type:ReagentThreshold
-          min: 10
+            Poison: 1.25
+      - !type:Jitter

--- a/Resources/Prototypes/Reagents/chemicals.yml
+++ b/Resources/Prototypes/Reagents/chemicals.yml
@@ -190,7 +190,7 @@
 - type: reagent
   id: Calomel
   name: reagent-name-calomel
-  group: Chemical
+  group: Toxin 
   desc: reagent-desc-calomel
   flavor: bitter
   color: "#6e4665"
@@ -208,7 +208,7 @@
 - type: reagent
   id: AmmoniatedMercury
   name: reagent-name-ammoniated-mercury
-  group: Medicine
+  group: Chemical
   desc: reagent-desc-ammoniated-mercury
   flavor: metallic
   color: "white"

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -504,7 +504,7 @@
 
 - type: reaction
   id: Calomel
-  impact: Medium
+  impact: Low
   minTemp: 374
   reactants:
     Mercury:

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -501,3 +501,28 @@
       amount: 1
   products:
     Tazinide: 1
+
+- type: reaction
+  id: Calomel
+  impact: Medium
+  minTemp: 374
+  reactants:
+    Mercury:
+      amount: 1
+    Chlorine:
+      amount: 1
+  products:
+    Calomel: 2
+
+- type: reaction
+  id: AmmoniatedMercury
+  impact: Medium
+  minTemp: 336
+  reactants:
+    Calomel:
+      amount: 1
+    Ammonia:
+      amount: 2
+  products:
+    AmmoniatedMercury: 2
+    AmmoniatedSludge: 1

--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -201,17 +201,3 @@
   effects:
     - !type:CreateEntityReactionEffect
       entity: MaterialGunpowder
-
-- type: reaction
-  id: AmmoniatedSludge
-  impact: Low
-  minTemp: 327
-  reactants:
-     Ammonia:
-       amount: 2
-     Slime:
-       amount: 1
-     Vomit:
-       amount: 2
-  products:
-     AmmoniatedSludge: 5


### PR DESCRIPTION
## About the PR
Removes the recipe for Ammoniated Sludge and makes it a byproduct of Ammoniated Mercury, adds Calomel.
## Why / Balance
More chems for more recipes in the future, makes ammoniated sludge not entirely useless.
