### PR TITLE
removes survival

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,10 +1,8 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.20
-    Traitor: 0.60
+    Nukeops: 0.25
+    Traitor: 0.65
     Zombie: 0.04
     Zombieteors: 0.01
-    Survival: 0.09
-    KesslerSyndrome: 0.01
     Revolutionary: 0.05


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes survival from secret pool

## Why / Balance
In categories:
Nobody likes 5 power shutoffs in 5 minutes, and the gamemode itself
Broken wizden spaghetti code, which can go fuck off until its fully reworked

