### PR TITLE
cloning research

### DIFF
--- a/Resources/Locale/en-US/ronstation/research/technologies.ftl
+++ b/Resources/Locale/en-US/ronstation/research/technologies.ftl
@@ -1,0 +1,1 @@
+research-technology-cloning = Cloning

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -518,6 +518,9 @@
       - MassMediaCircuitboard
       - ReagentGrinderIndustrialMachineCircuitboard
       - JukeboxCircuitBoard
+      - CloningPodMachineCircuitboard
+      - MedicalScannerMachineCircuitboard
+      - CloningConsoleComputerCircuitboard
   - type: EmagLatheRecipes
     emagDynamicRecipes:
       - ShuttleGunDusterCircuitboard

--- a/Resources/Prototypes/Ronstation/Research/civilianservices.yml
+++ b/Resources/Prototypes/Ronstation/Research/civilianservices.yml
@@ -1,0 +1,13 @@
+- type: technology
+  id: Cloning
+  name: research-technology-cloning
+  icon:
+    sprite: /Structures/Machines/scanner.rsi
+    state: open
+  discipline: CivilianServices
+  tier: 3
+  cost: 10000
+  recipeUnlocks:
+  - CloningPodMachineCircuitboard
+  - MedicalScannerMachineCircuitboard
+  - CloningConsoleComputerCircuitboard

--- a/Resources/Prototypes/Ronstation/Research/civilianservices.yml
+++ b/Resources/Prototypes/Ronstation/Research/civilianservices.yml
@@ -2,7 +2,7 @@
   id: Cloning
   name: research-technology-cloning
   icon:
-    sprite: /Structures/Machines/scanner.rsi
+    sprite: Structures/Machines/scanner.rsi
     state: open
   discipline: CivilianServices
   tier: 3


### PR DESCRIPTION

## About the PR
added cloning research as a civ tier 3 thingie

## Why / Balance
cloning was murdered by wizden, this PR resurrects it

## Technical details
no

## Media

## Requirements

## Breaking changes

**Changelog**
You can now research cloning. It's a tier 3 civ tech.
