### PR TITLE
opporozidone buff

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1174,7 +1174,7 @@
     Medicine:
       effects:
         - !type:ReduceRotting
-          seconds: 20
+          seconds: 30
           conditions:
           #Patient must be dead and in a cryo tube (or something cold)
           - !type:Temperature

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -564,9 +564,10 @@
     Cognizine: 
       amount: 1
     Plasma:
-      amount: 2
-    Doxarubixadone:
       amount: 1
+      catalyst: true
+    Doxarubixadone:
+      amount: 2
   products:
     Opporozidone: 3
 

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -565,7 +565,6 @@
       amount: 1
     Plasma:
       amount: 1
-      catalyst: true
     Doxarubixadone:
       amount: 2
   products:


### PR DESCRIPTION
## About the PR
Slightly changes the recipe for opporozidone and gives it a small buff.

## Why / Balance
Opporozidone - " a difficult to synthesize cryogenic drug", requires at least more than 50 units to reverse half of the rotting on a dead person, keep in mind though, that rotting people generally have _(some)_ genetic/poison damage, and some other damage in high quantity too, which is almost impossible to heal without more cryogenic chemicals/high amounts of topicals.
This makes it a bit more rewarding, since it requires less reagents _(requires 1 more part of doxarubixadone)_ to make, and opporozidone to fully rejuvenate a corpse.
