### PR TITLE
Biogenerator updates + new chemicals

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1161,6 +1161,11 @@
     - BioGenMilk
     - BioGenMilkSoy
     - BioGenEthanol
+    - BioGenNitrogen
+    - BioGenPhosphorus
+    - BioGenHydrogen
+    - BioGenOxygen
+    - BioGenPotassium
     - BioGenCream
     - BioGenBlackpepper
     - BioGenEnzyme

--- a/Resources/Prototypes/Recipes/Lathes/biogen.yml
+++ b/Resources/Prototypes/Recipes/Lathes/biogen.yml
@@ -169,6 +169,66 @@
     Biomass: 18
 
 - type: latheRecipe
+  id: BioGenNitrogen
+  resultReagents:
+    Nitrogen: 10
+  category: Food
+  icon:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 24
+
+- type: latheRecipe
+  id: BioGenHydrogen
+  resultReagents:
+    Hydrogen: 10
+  category: Food
+  icon:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 18
+
+- type: latheRecipe
+  id: BioGenOxygen
+  resultReagents:
+    Oxygen: 10
+  category: Food
+  icon:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 18
+
+- type: latheRecipe
+  id: BioGenPhosphorus
+  resultReagents:
+    Phosphorus: 10
+  category: Food
+  icon:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 24
+
+- type: latheRecipe
+  id: BioGenPotassium
+  resultReagents:
+    Potassium: 10
+  category: Food
+  icon:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  completetime: 1
+  materials:
+    Biomass: 18
+
+- type: latheRecipe
   id: BioGenCream
   resultReagents:
     Cream: 10


### PR DESCRIPTION

# Do not merge, yet in development
## About the PR
Instead of begging chemistry, botany can now make their own potassium, phosphorus, nitrogen, hydrogen and oxygen.
## Other changes:
- Calcium hydroxide
- Barium hydroxide
- Magnesium hydroxide
- More...