### PR TITLE
Fixes and other stuff.

### DIFF
--- a/Resources/Locale/en-US/tips.ftl
+++ b/Resources/Locale/en-US/tips.ftl
@@ -135,4 +135,4 @@ tips-dataset-134 = You can tell if an area with firelocks up is spaced by lookin
 tips-dataset-135 = Instead of picking it up, you can alt-click food to eat it. This also works for mice and other creatures without hands.
 tips-dataset-136 = If you're trapped behind an electrified door, disable the APC or throw your ID at the door to avoid getting shocked!
 tips-dataset-137 = If the AI electrifies a door and you have insulated gloves, snip and mend the power wire to reset their electrification!
-tips-dataset-136 = You can get free steel from walls.
+tips-dataset-139 = You can get free steel from walls.

--- a/Resources/Locale/en-US/tips.ftl
+++ b/Resources/Locale/en-US/tips.ftl
@@ -135,4 +135,4 @@ tips-dataset-134 = You can tell if an area with firelocks up is spaced by lookin
 tips-dataset-135 = Instead of picking it up, you can alt-click food to eat it. This also works for mice and other creatures without hands.
 tips-dataset-136 = If you're trapped behind an electrified door, disable the APC or throw your ID at the door to avoid getting shocked!
 tips-dataset-137 = If the AI electrifies a door and you have insulated gloves, snip and mend the power wire to reset their electrification!
-tips-dataset-139 = You can get free steel from walls.
+tips-dataset-138 = You can get free steel from walls.

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -48,6 +48,7 @@
   - ERTSecurity
   - ERTEngineer
   - DeathSquad
+  - BlueshieldOfficer
   editorHidden: true
   weight: 120
 

--- a/Resources/Prototypes/Ronstation/Entities/Clothing/Back/backpack.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Clothing/Back/backpack.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingBackpack, BaseCommandContraband]
+  parent: [ClothingBackpack, BaseCentcommCommandContraband]
   id: ClothingBackpackBlueshield
   name: blueshield backpack
   description: It's a very robust backpack, even if your job is to protect heads of staff.

--- a/Resources/Prototypes/Ronstation/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Clothing/Back/duffel.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingBackpackDuffel, BaseCommandContraband]
+  parent: [ClothingBackpackDuffel, BaseCentcommCommandContraband]
   id: ClothingBackpackDuffelBlueshield
   name: blueshield duffel bag
   description: A large duffel bag for holding extra blueshield related goods.

--- a/Resources/Prototypes/Ronstation/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Clothing/Back/satchel.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingBackpackSatchel, BaseCommandContraband]
+  parent: [ClothingBackpackSatchel, BaseCentcommCommandContraband]
   id: ClothingBackpackSatchelBlueshield
   name: Blueshield satchel
   description: A robust satchel for blueshield related needs.

--- a/Resources/Prototypes/Ronstation/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Clothing/Eyes/glasses.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingEyesGlassesSecurity
+  parent: [ClothingEyesGlassesSecurity, BaseRestrictedContraband]
   id: ClothingEyesGlassesSecurityVisor
   name: security visor
   description: Upgraded sunglasses that provide flash immunity and a security HUD. Looks badass.

--- a/Resources/Prototypes/Ronstation/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Clothing/Head/hats.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingHeadBase
+  parent: [ClothingHeadBase, BaseCentcommCommandContraband]
   id: ClothingHeadHatBeretBlueshield
   name: blueshield beret
   description: A stylish clothing option for blueshield officers.

--- a/Resources/Prototypes/Ronstation/Entities/Clothing/Head/soft.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Clothing/Head/soft.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingHeadHeadHatBaseFlippable
+  parent: [ClothingHeadHeadHatBaseFlippable, BaseCentcommCommandContraband]
   id: ClothingHeadHatBlueshieldsoft # Prototype ID is named "ClothingHeadHatBlueshieldsoft" because there's already a prototype with an ID named "ClothingHeadHatBluesoft"
   name: blueshield cap
   description: It's a robust baseball hat in tasteful red colour.
@@ -10,6 +10,6 @@
     sprite: Ronstation/Clothing/Head/Soft/blueshieldsoft.rsi
 
 - type: entity
-  parent: [ClothingHeadHeadHatBaseFlipped, ClothingHeadHatBlueshieldsoft]
+  parent: [ClothingHeadHeadHatBaseFlipped, ClothingHeadHatBlueshieldsoft, BaseCentcommCommandContraband]
   id: ClothingHeadHatBlueshieldsoftFlipped
   name: blueshield cap

--- a/Resources/Prototypes/Ronstation/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Clothing/Neck/misc.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseCentcommCommandContraband]
   id: Dinkyshield
   name: blue shield sticker
   description: A dinky lil blue shield for only the hardest working blueshield officers! It's not even sticky anymore.

--- a/Resources/Prototypes/Ronstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1,6 +1,6 @@
 #Heccdiver Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseTerragovContraband]
+  parent: [ BaseTerragovContraband, ClothingOuterHardsuitSecurity ]
   id: ClothingOuterHardsuitHeccdiver
   name: heccdiver hardsuit
   description: An elite suit used by an elite task force.
@@ -9,21 +9,5 @@
     sprite: Ronstation/Clothing/OuterClothing/Hardsuits/heccdiver.rsi
   - type: Clothing
     sprite: Ronstation/Clothing/OuterClothing/Hardsuits/heccdiver.rsi
-  - type: PressureProtection
-    highPressureMultiplier: 0.5
-    lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.4
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.6
-        Caustic: 0.7
-  - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
-  - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitHeccdiver

--- a/Resources/Prototypes/Ronstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1,6 +1,6 @@
 #Heccdiver Hardsuit
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseTerragovContraband ]
+  parent: [ClothingOuterHardsuitBase, BaseTerragovContraband]
   id: ClothingOuterHardsuitHeccdiver
   name: heccdiver hardsuit
   description: An elite suit used by an elite task force.
@@ -22,8 +22,8 @@
         Piercing: 0.6
         Caustic: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 0.90
-    sprintModifier: 0.90
+    walkModifier: 0.75
+    sprintModifier: 0.75
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitHeccdiver

--- a/Resources/Prototypes/Ronstation/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Clothing/Shoes/boots.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingShoesBaseWinterBoots, ClothingShoesMilitaryBase, BaseCommandContraband]
+  parent: [ClothingShoesBaseWinterBoots, ClothingShoesMilitaryBase, BaseCentcommCommandContraband]
   id: ClothingShoesBootsWinterBlueshield
   name: blueshield winter boots
   components:

--- a/Resources/Prototypes/Ronstation/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingUniformBase, BaseCommandContraband]
+  parent: [ClothingUniformBase, BaseCentcommCommandContraband]
   id: ClothingUniformJumpskirtBlueshieldGrey
   name: grey blueshield jumpsuit
   description: The main suit of the protector.
@@ -10,7 +10,7 @@
     sprite: Ronstation/Clothing/Uniforms/Jumpskirt/blueshield_grey.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCentcommCommandContraband]
   id: ClothingUniformJumpskirtBlueshield
   name: blueshield jumpskirt
   description: A jumpskirt made of strong material, providing robust protection, even for a bodyguard.

--- a/Resources/Prototypes/Ronstation/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BaseTerragovContraband, UnsensoredClothingUniformBase ]
+  parent: [ UnsensoredClothingUniformBase, BaseTerragovContraband ]
   id: ClothingUniformJumpsuitHeccdiver
   name: heccdiver jumpsuit
   description: The very capable wear this, apparently.
@@ -10,7 +10,7 @@
     sprite: Ronstation/Clothing/Uniforms/Jumpsuit/heccdiver.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseCommandContraband]
+  parent: [ClothingUniformBase, BaseCentcommCommandContraband]
   id: ClothingUniformJumpsuitBlueshieldGrey
   name: grey blueshield jumpsuit
   description: The main suit of the protector.
@@ -21,7 +21,7 @@
     sprite: Ronstation/Clothing/Uniforms/Jumpsuit/blueshield_grey.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCentcommCommandContraband]
   id: ClothingUniformJumpsuitBlueshield
   name: blueshield jumpsuit
   description: A jumpsuit made of strong material, providing robust protection, even for a bodyguard.

--- a/Resources/Prototypes/Ronstation/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ UnsensoredClothingUniformBase, BaseTerragovContraband ]
+  parent: [ BaseTerragovContraband, UnsensoredClothingUniformBase ]
   id: ClothingUniformJumpsuitHeccdiver
   name: heccdiver jumpsuit
   description: The very capable wear this, apparently.

--- a/Resources/Prototypes/Ronstation/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Objects/Devices/Electronics/door_access.yml
@@ -1,3 +1,4 @@
+# Command
 - type: entity
   parent: DoorElectronics
   id: DoorElectronicsBlueshield

--- a/Resources/Prototypes/Ronstation/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Objects/Devices/pda.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BasePDA, BaseTerragovContraband ]
+  parent: [ BaseTerragovContraband, BasePDA ]
   id: HeccdiverPDA
   name: heccdiver PDA
   description: Ok, time to be a productive member of- oh cool I'm a heccdiver time to give this world a taste of managed democracy!

--- a/Resources/Prototypes/Ronstation/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Objects/Devices/pda.yml
@@ -29,7 +29,7 @@
           - Cartridge
 
 - type: entity
-  parent: [ BasePDA, BaseCommandContraband ]
+  parent: [ BasePDA, BaseCentcommCommandContraband ]
   id: BlueshieldPDA
   name: Blueshield PDA
   description: Might allow you to see who to protect through the crew manifest.

--- a/Resources/Prototypes/Ronstation/Entities/Objects/Devices/radio.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Objects/Devices/radio.yml
@@ -4,11 +4,6 @@
   parent: [ RadioHandheld, BaseTerragovContraband ]
   id: RadioHandheldTerragov
   components:
-  - type: RadioMicrophone
-    broadcastChannel: Handheld #Cannot make a new channel for Terragov.
-  - type: RadioSpeaker
-    channels:
-    - Handheld
   - type: Sprite
     sprite: Ronstation/Objects/Devices/terragovhandy.rsi
   - type: Item

--- a/Resources/Prototypes/Ronstation/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Objects/Misc/identification_cards.yml
@@ -2,7 +2,7 @@
 #IDs with layers
 
 - type: entity
-  parent: [ IDCardStandard, BaseTerragovContraband ]
+  parent: [ BaseTerragovContraband, IDCardStandard ]
   id: HeccdiverIDCard
   name: heccdiver ID card
   components:

--- a/Resources/Prototypes/Ronstation/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Objects/base_contraband.yml
@@ -5,5 +5,3 @@
   components:
   - type: Contraband
     severity: Terragov
-    # no one should be carrying this around visibly!
-    allowedDepartments: null

--- a/Resources/Prototypes/Ronstation/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Structures/Doors/Airlocks/access.yml
@@ -10,7 +10,7 @@
 
 - type: entity
   parent: AirlockCentralCommandGlass
-  id: AirlockBlueshieldLocked
+  id: AirlockBlueshieldGlassLocked
   suffix: Blueshield, Locked
   components:
   - type: AccessReader

--- a/Resources/Prototypes/Ronstation/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Structures/Doors/Airlocks/access.yml
@@ -1,8 +1,19 @@
 - type: entity
-  parent: AirlockCommand
+  parent: AirlockCentralCommand
   id: AirlockBlueshieldLocked
   suffix: Blueshield, Locked
   components:
-  - type: ContainerFill
-    containers:
-      board: [ DoorElectronicsBlueshield ]
+  - type: AccessReader
+    access: [["Blueshield"]]
+  - type: Wires
+    layoutId: AirlockCommand
+
+- type: entity
+  parent: AirlockCentralCommandGlass
+  id: AirlockBlueshieldLocked
+  suffix: Blueshield, Locked
+  components:
+  - type: AccessReader
+    access: [["Blueshield"]]
+  - type: Wires
+    layoutId: AirlockCommand


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Fixes the numbering of a particular dataset.
- Fixes contraband on Terragov items.
- Moves Blueshield to Centcomm.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- This error came up, due to the number of our custom tip being overlooked, causing it and another one to have the same number. This resolves this issue.

- Somehow, an upstream PR caused the `allowedDepartments: null` in the contraband prototypes to cause error.

- Blueshield are supposed to be CentComm dignitaries, so their stuff should be CentComm contraband.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed numbering of our custom tip being the same as another tip. 
- fix: Removed the `allowedDepartments: null`, as it’s causing errors.
- tweak: Blueshield items are now centcomm contraband.
- tweak: Blueshield airlocks are now centcomm airlocks.