### PR TITLE
more chemistry + EE chem ports

### DIFF
--- a/Resources/Locale/en-US/_Ronstation/reagents/cyanide.ftl
+++ b/Resources/Locale/en-US/_Ronstation/reagents/cyanide.ftl
@@ -1,0 +1,1 @@
+cyanide-effect-horrendously-weak = You feel horrendously weak!

--- a/Resources/Locale/en-US/_Ronstation/reagents/meta/chemicals.ftl
+++ b/Resources/Locale/en-US/_Ronstation/reagents/meta/chemicals.ftl
@@ -1,0 +1,14 @@
+reagent-name-formaldehyde = formaldehyde
+reagent-desc-formaldehyde = Formaldehyde, on its own, is a fairly weak toxin. It contains trace amounts of Histamine, very rarely making it decay into Histamine.
+
+reagent-name-cyanide = cyanide
+reagent-desc-cyanide = An infamous poison known for its use in assassination. Causes small amounts of toxin damage with a small chance of oxygen damage or a stun.
+
+reagent-name-chloroform = chloroform
+reagent-desc-chloroform = Hold tight, sleep tight. Nighty night. Makes you sleepy if inhaled, but not effectively. Quite the nuisance and causes weak organ damage.
+
+reagent-name-saltpetre = saltpetre
+reagent-desc-saltpetre = A common fertilizer, and explosive. Volatile.
+
+reagent-name-caffeine = caffeine
+reagent-desc-caffeine = Keeps you up at night and at day.

--- a/Resources/Locale/en-US/_Ronstation/reagents/meta/elements.ftl
+++ b/Resources/Locale/en-US/_Ronstation/reagents/meta/elements.ftl
@@ -1,0 +1,2 @@
+reagent-name-bromine = bromine
+reagent-desc-bromine = A brownish-red in color, gaseous carcinogenic.

--- a/Resources/Locale/en-US/_Ronstation/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/_Ronstation/reagents/meta/medicine.ftl
@@ -1,0 +1,11 @@
+reagent-name-rezadone = rezadone
+reagent-desc-rezadone = A powder derived from fish toxin, Rezadone can effectively restore corpses husked by burns as well as treat minor wounds. Overdose will cause intense nausea and minor toxin damage.
+
+reagent-name-pentetic-acid = pentetic acid
+reagent-desc-pentetic-acid = Reduces toxin and radiation damage while purging other chemicals from the body.
+
+reagent-name-cordrazine = cordrazine
+reagent-desc-cordrazine = Reduces brute, toxin and airloss damage while in critical condition. Overdose causes cellular scrambling and possible delirium.
+
+reagent-name-salicylic-acid = salicylic acid
+reagent-desc-salicylic-acid = Stimulates the healing of severe bruises. Extremely rapidly heals severe bruising and slowly heals minor ones. Overdose will worsen existing bruising.

--- a/Resources/Locale/en-US/_Ronstation/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/_Ronstation/reagents/meta/medicine.ftl
@@ -1,5 +1,5 @@
 reagent-name-rezadone = rezadone
-reagent-desc-rezadone = A powder derived from fish toxin, Rezadone can effectively restore corpses husked by burns as well as treat minor wounds. Overdose will cause intense nausea and minor toxin damage.
+reagent-desc-rezadone = A powder derived from fish toxin, effectively restores burns as well as treat minor wounds. Overdose will cause intense nausea and minor toxin damage.
 
 reagent-name-pentetic-acid = pentetic acid
 reagent-desc-pentetic-acid = Reduces toxin and radiation damage while purging other chemicals from the body.
@@ -9,3 +9,6 @@ reagent-desc-cordrazine = Reduces brute, toxin and airloss damage while in criti
 
 reagent-name-salicylic-acid = salicylic acid
 reagent-desc-salicylic-acid = Stimulates the healing of severe bruises. Extremely rapidly heals severe bruising and slowly heals minor ones. Overdose will worsen existing bruising.
+
+reagent-name-spaceacillin = spaceacillin
+reagent-desc-spaceacillin = Provides limited resistance against disease and parasites. Not used as much due to the extinction of most pathogens.

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -5,6 +5,7 @@
     JugAluminium: 2
     JugCarbon: 4
     JugChlorine: 1
+    JugBromine: 1
     JugCopper: 2
     JugEthanol: 2
     JugFluorine: 1
@@ -35,6 +36,7 @@
     JugAluminium: 2
     JugCarbon: 4
     JugChlorine: 1
+    JugBromine: 2
     JugCopper: 2
     JugEthanol: 2
     JugFluorine: 1

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -443,3 +443,18 @@
         reagents:
         - ReagentId: WeldingFuel
           Quantity: 200
+
+- type: entity
+  parent: Jug
+  suffix: bromine
+  id: JugBromine
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Label
+    currentLabel: reagent-name-bromine
+  - type: SolutionContainerManager
+    solutions:
+      beaker:
+        reagents:
+        - ReagentId: Bromine
+          Quantity: 200

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -19,6 +19,9 @@
       - !type:AdjustReagent
         reagent: Theobromine
         amount: 0.05
+       - !type:AdjustReagent
+        reagent: Caffeine
+        amount: 0.03
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/coffeeglass.rsi
     state: icon_empty
@@ -109,6 +112,9 @@
         key: Drowsiness
         time: 2.0
         type: Remove
+       - !type:AdjustReagent
+        reagent: Caffeine
+        amount: 0.02
 
 - type: reagent
   id: GreenTea
@@ -167,6 +173,9 @@
         key: Drowsiness
         time: 2.0
         type: Remove
+      - !type:AdjustReagent
+        reagent: Caffeine
+        amount: 0.02
 
 - type: reagent
   id: IcedGreenTea

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -19,7 +19,7 @@
       - !type:AdjustReagent
         reagent: Theobromine
         amount: 0.05
-       - !type:AdjustReagent
+      - !type:AdjustReagent
         reagent: Caffeine
         amount: 0.03
   metamorphicSprite:
@@ -112,7 +112,7 @@
         key: Drowsiness
         time: 2.0
         type: Remove
-       - !type:AdjustReagent
+      - !type:AdjustReagent
         reagent: Caffeine
         amount: 0.02
 

--- a/Resources/Prototypes/_Ronstation/Reagents/chemicals.yml
+++ b/Resources/Prototypes/_Ronstation/Reagents/chemicals.yml
@@ -7,7 +7,7 @@
   boilingPoint: 298.75
   meltingPoint: 259.86
   metabolisms:
-    metabolismRate: 0.125
+    metabolismRate: 0.15
     Poison:
       effects:
       - !type:HealthChange

--- a/Resources/Prototypes/_Ronstation/Reagents/chemicals.yml
+++ b/Resources/Prototypes/_Ronstation/Reagents/chemicals.yml
@@ -1,0 +1,169 @@
+- type: reagent
+  id: Cyanide
+  name: reagent-name-cyanide
+  desc: reagent-desc-cyanide
+  physicalDesc: reagent-physical-desc-opaque
+  color: "#00B4FF"
+  boilingPoint: 298.75
+  meltingPoint: 259.86
+  metabolisms:
+    metabolismRate: 0.125
+    Poison:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: 1
+            Asphyxiation: 1
+      - !type:PopupMessage
+        type: Local
+        visualType: MediumCaution
+        messages: [ "cyanide-effect-horrendously-weak" ]
+        probability: 0.1
+      - !type:GenericStatusEffect
+        key: KnockedDown
+        time: 4
+        type: Add
+        probability: 0.1
+
+- type: reagent
+  id: Formaldehyde
+  name: reagent-name-formaldehyde
+  desc: reagent-desc-formaldehyde
+  physicalDesc: reagent-physical-desc-pungent
+  color: "#B4004B"
+  boilingPoint: 254.15
+  meltingPoint: 180.92
+  metabolisms:
+    Poison:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: 0.5
+      - !type:AdjustReagent
+        probability: 0.3
+        reagent: Histamine
+        amount: 0.5
+
+- type: reagent
+  id: Chloroform
+  name: reagent-name-chloroform
+  desc: reagent-desc-chloroform
+  physicalDesc: reagent-physical-desc-opaque
+  flavor: sweet
+  color: "#D2D2D2"
+  boilingPoint: 334.30
+  meltingPoint: 209.65
+  metabolisms:
+    metabolismRate: 0.4
+    Poison:
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Chloroform
+          min: 10
+        damage:
+          types:
+            Poison: 0.2
+      - !type:GenericStatusEffect
+        key: Drowsiness
+        component: Drowsiness
+        time: 1.25
+        type: Add
+        refresh: false
+  reactiveEffects:
+    Acidic:
+      methods: [ Touch ]
+      effects:
+      - !type:HealthChange
+        ignoreResistances: false
+        damage:
+          types:
+            Poison: 0.05
+      - !type:GenericStatusEffect
+        key: Drowsiness
+        component: Drowsiness
+        time: 2.5
+        type: Add
+        refresh: false
+      - !type:MovespeedModifier
+        walkSpeedModifier: 0.75
+        sprintSpeedModifier: 0.75
+
+- type: reagent
+  id: Saltpetre
+  name: reagent-name-saltpetre
+  desc: reagent-desc-saltpetre
+  physicalDesc: reagent-physical-desc-powdery
+  flavor: salty
+  color: "#F0F0F0"
+  boilingPoint: 673.0
+  meltingPoint: 607.15
+  plantMetabolism:
+  - !type:PlantAdjustNutrition
+    amount: 1
+  - !type:PlantAdjustHealth
+    amount: 1
+  - !type:PlantAdjustPotency
+    amount: 2
+  metabolisms:
+    metabolismRate: 0.4
+    Medicine:
+      effects:
+      - !type:HealthChange
+        damage:
+          groups:
+            Brute: -0.15
+            Burn: -0.15
+        conditions:
+        - !type:OrganType
+          type: Plant
+
+- type: reagent
+  id: Caffeine
+  name: reagent-name-caffeine
+  desc: reagent-desc-caffeine
+  physicalDesc: reagent-physical-desc-powdery
+  flavor: bitter
+  color: "#E6DCE6"
+  boilingPoint: 507.0
+  meltingPoint: 170.0
+  plantMetabolism:
+  - !type:PlantAdjustNutrition
+    amount: -0.5
+  - !type:PlantAdjustHealth
+    amount: -0.5
+  metabolisms:
+    Narcotic:
+      metabolismRate: 0.6
+      effects:
+      - !type:MovespeedModifier
+        walkSpeedModifier: 1.10
+        sprintSpeedModifier: 1.10
+      - !type:GenericStatusEffect
+        key: Drowsiness
+        time: 2
+        type: Remove
+        probability: 0.5
+      - !type:GenericStatusEffect
+        key: KnockedDown
+        time: 2
+        type: Remove
+        probability: 0.5
+      - !type:GenericStatusEffect
+        key: Stun
+        time: 2
+        type: Remove
+        probability: 0.5
+    Poison:
+      metabolismRate: 0.5
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 15
+        damage:
+          types:
+            Poison: 0.5

--- a/Resources/Prototypes/_Ronstation/Reagents/chemicals.yml
+++ b/Resources/Prototypes/_Ronstation/Reagents/chemicals.yml
@@ -7,8 +7,8 @@
   boilingPoint: 298.75
   meltingPoint: 259.86
   metabolisms:
-    metabolismRate: 0.15
     Poison:
+      metabolismRate: 0.15
       effects:
       - !type:HealthChange
         damage:
@@ -56,8 +56,8 @@
   boilingPoint: 334.30
   meltingPoint: 209.65
   metabolisms:
-    metabolismRate: 0.4
     Poison:
+      metabolismRate: 0.4
       effects:
       - !type:HealthChange
         conditions:
@@ -109,8 +109,8 @@
   - !type:PlantAdjustPotency
     amount: 2
   metabolisms:
-    metabolismRate: 0.4
     Medicine:
+      metabolismRate: 0.4
       effects:
       - !type:HealthChange
         damage:

--- a/Resources/Prototypes/_Ronstation/Reagents/elements.yml
+++ b/Resources/Prototypes/_Ronstation/Reagents/elements.yml
@@ -1,0 +1,26 @@
+- type: reagent
+  id: Bromine
+  name: reagent-name-bromine
+  group: Elements
+  desc: reagent-desc-bromine
+  physicalDesc: reagent-physical-desc-gaseous
+  flavor: bitter
+  color: "#752817"
+  meltingPoint: 266.3
+  boilingPoint: 332.6
+  plantMetabolism:
+    - !type:PlantAdjustWater
+      amount: -0.5
+    - !type:PlantAdjustToxins
+      amount: 15
+    - !type:PlantAdjustWeeds
+      amount: -1.5
+    - !type:PlantAdjustHealth
+      amount: -1.5
+  metabolisms:
+    Poison:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: 2

--- a/Resources/Prototypes/_Ronstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Ronstation/Reagents/medicine.yml
@@ -1,0 +1,132 @@
+- type: reagent
+  id: PenteticAcid
+  name: reagent-name-pentetic-acid
+  group: Medicine
+  desc: reagent-desc-pentetic-acid
+  physicalDesc: reagent-physical-desc-powdery
+  color: "#E6FFF0"
+  worksOnTheDead: true
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.6
+      effects:
+      - !type:HealthChange
+        probability: 0.70
+        damage:
+          groups:
+            Toxin: -4
+      - !type:HealthChange
+        probability: 0.30
+        damage:
+          groups:
+            Burn: 0.5
+            Brute: 0.5
+      - !type:ChemCleanBloodstream
+        cleanseRate: 5
+
+- type: reagent
+  id: Rezadone
+  name: reagent-name-rezadone
+  group: Medicine
+  desc: reagent-desc-rezadone
+  physicalDesc: reagent-physical-desc-powdery
+  flavor: fishy
+  color: "#669900"
+  worksOnTheDead: true
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.4
+      effects:
+      - !type:HealthChange
+        damage:
+          groups:
+            Brute: -1
+            Burn: -1
+          types:
+            Cellular: -0.10
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          groups:
+            Toxin: 1
+      - !type:Jitter
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+      - !type:PopupMessage
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        type: Local
+        visualType: Medium
+        messages: [ "generic-reagent-effect-nauseous" ]
+        probability: 0.3
+      - !type:ChemVomit
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+
+- type: reagent
+  id: Cordrazine
+  name: reagent-name-cordrazine
+  group: Medicine
+  desc: reagent-desc-cordrazine
+  physicalDesc: reagent-physical-desc-viscous
+  flavor: medicine
+  color: "#942222"
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.6
+      effects:
+        - !type:HealthChange
+          conditions:
+          - !type:MobStateCondition
+            mobstate: Critical
+          damage:
+            groups:
+              Brute: -0.5
+            types:
+              Asphyxiation: -1
+              Poison: -0.5
+        - !type:HealthChange
+          conditions:
+          - !type:MobStateCondition
+            mobstate: Alive
+          damage:
+            groups:
+              Brute: -0.1
+              Burn: -0.1
+        - !type:HealthChange
+          conditions:
+          - !type:ReagentThreshold
+            min: 20
+          damage:
+            types:
+              Cellular: 0.5
+
+- type: reagent
+  id: SalicylicAcid
+  name: reagent-name-salicylic-acid
+  group: Medicine
+  desc: reagent-desc-salicylic-acid
+  physicalDesc: reagent-physical-desc-powdery
+  flavor: medicine
+  color: "#D2D2D2"
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.1
+      effects:
+        - !type:HealthChange
+          probability: 0.55
+          damage:
+            groups:
+              Brute: -3
+        - !type:HealthChange
+          conditions:
+          - !type:ReagentThreshold
+            min: 30
+          damage:
+            groups:
+              Toxin: 1

--- a/Resources/Prototypes/_Ronstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Ronstation/Reagents/medicine.yml
@@ -130,3 +130,21 @@
           damage:
             groups:
               Toxin: 1
+
+- type: reagent
+  id: Spaceacillin
+  name: reagent-name-spaceacillin
+  group: Medicine
+  desc: reagent-desc-spaceacillin
+  physicalDesc: reagent-physical-desc-viscous
+  flavor: medicine
+  color: "#E1F2E6"
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.1
+      effects:
+        - !type:HealthChange
+          damage:
+            groups:
+              Toxin: -0.6
+              Burn: -0.3

--- a/Resources/Prototypes/_Ronstation/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/_Ronstation/Recipes/Reactions/chemicals.yml
@@ -1,0 +1,69 @@
+- type: reaction
+  id: Cyanide
+  reactants:
+    Oil:
+      amount: 1
+    Ammonia:
+      amount: 1
+    Oxygen:
+      amount: 1
+  products:
+    Cyanide: 3
+
+- type: reaction
+  id: Formaldehyde
+  reactants:
+    Ethanol:
+      amount: 1
+    Oxygen:
+      amount: 1
+    Silver:
+      amount: 1
+  products:
+    Formaldehyde: 3
+
+- type: reaction
+  id: Chloroform
+  reactants:
+    Acetone:
+      amount: 1
+    Bleach:
+      amount: 1
+  effects:
+  - !type:CreateGas
+    gas: Oxygen
+  products:
+    Chloroform: 1
+
+- type: reaction
+  id: Caffeine
+  reactants:
+    Chloroform:
+      amount: 0.1
+      catalyst: true
+    Coffee:
+      amount: 1
+  products:
+    Caffeine: 1
+
+- type: reaction
+  id: CaffeineLatte
+  reactants:
+    Chloroform:
+      amount: 0.1
+      catalyst: true
+    CafeLatte:
+      amount: 2 # not pure
+  products:
+    Caffeine: 0.5
+
+- type: reaction
+  id: CaffeineIced
+  reactants:
+    Chloroform:
+      amount: 0.1
+      catalyst: true
+    IcedCoffee:
+      amount: 2 # not pure
+  products:
+    Caffeine: 0.5

--- a/Resources/Prototypes/_Ronstation/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/_Ronstation/Recipes/Reactions/chemicals.yml
@@ -15,12 +15,10 @@
   reactants:
     Ethanol:
       amount: 1
-    Oxygen:
-      amount: 1
     Silver:
       amount: 1
   products:
-    Formaldehyde: 3
+    Formaldehyde: 2
 
 - type: reaction
   id: Chloroform

--- a/Resources/Prototypes/_Ronstation/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_Ronstation/Recipes/Reactions/medicine.yml
@@ -1,7 +1,7 @@
 - type: reaction
   id: Rezadone
   reactants:
-    Carpotoxin:
+    CarpoToxin:
       amount: 1
     Spaceacillin:
       amount: 1

--- a/Resources/Prototypes/_Ronstation/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_Ronstation/Recipes/Reactions/medicine.yml
@@ -1,0 +1,55 @@
+- type: reaction
+  id: Rezadone
+  reactants:
+    Carpotoxin:
+      amount: 1
+    Spaceacillin:
+      amount: 1
+    Copper:
+      amount: 1
+  products:
+    Rezadone: 3
+
+- type: reaction
+  id: PenteticAcid
+  reactants:
+    WeldingFuel:
+      amount: 1
+    Chlorine:
+      amount: 1
+    Ammonia:
+      amount: 1
+    Sodium:
+      amount: 1
+    Cyanide:
+      amount: 1
+    Formaldehyde:
+      amount: 1
+  products:
+    PenteticAcid: 3
+
+- type: reaction
+  id: Cordrazine
+  reactants:
+    Bromine:
+      amount: 1
+    Inaprovaline:
+      amount: 1
+    Lithium:
+      amount: 1
+  products:
+    Cordrazine: 2
+
+- type: reaction
+  id: SalicylicAcid
+  reactants:
+    Oxygen:
+      amount: 2
+    Carbon:
+      amount: 2
+    Phenol:
+      amount: 1
+    SulfuricAcid:
+      amount: 1
+  products:
+    SalicylicAcid: 3


### PR DESCRIPTION
## About the PR
Additions:
- Chemicals:
Cyanide
Formaldehyde
Chloroform
Saltpetre
Caffeine
- Medicine:
Pentetic acid
Rezadone
Cordrazine
Salicylic acid
Spaceacillin (for one recipe)

## Why / Balance
Fun. Ports chemicals from the EE version to here.

## Technical details
Just YAML editing. Adds _Ronstation to Prototypes. Adds FTL folder for Locale.

## Media
none yet

## Breaking changes
Edits Prototypes/Reagents/Consumables/Drink/drinks.yml. May conflict at a later time.
