### PR TITLE
Allow atmos fire-axe to pry plating.

### DIFF
--- a/Resources/Locale/en-US/tools/tool-qualities.ftl
+++ b/Resources/Locale/en-US/tools/tool-qualities.ftl
@@ -1,6 +1,9 @@
 tool-quality-anchoring-name = Anchoring
 tool-quality-anchoring-tool-name = Wrench
 
+tool-quality-axing-name = Axing
+tool-quality-axing-tool-name = Fireaxe
+
 tool-quality-prying-name = Prying
 tool-quality-prying-tool-name = Crowbar
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -41,6 +41,7 @@
   - type: Tool
     qualities:
       - Prying
+      - Axing
   - type: ToolTileCompatible
   - type: Prying
   - type: UseDelay
@@ -68,3 +69,6 @@
     quickEquip: false
     slots:
     - back
+  - type: Tool
+    qualities:
+      - Prying

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -4,6 +4,7 @@
   sprite: /Textures/Tiles/plating.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -20,6 +21,7 @@
   - 1.0
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -31,6 +33,7 @@
   sprite: /Textures/Tiles/Asteroid/asteroid_plating.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -42,6 +45,7 @@
   sprite: /Textures/Tiles/Misc/clockwork/clockwork_floor.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -53,6 +57,7 @@
   sprite: /Textures/Tiles/snow_plating.png #Not in the snow planet RSI because it doesn't have any metadata. Should probably be moved to its own folder later.
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.15 #a little less then actual snow

--- a/Resources/Prototypes/tool_qualities.yml
+++ b/Resources/Prototypes/tool_qualities.yml
@@ -6,6 +6,13 @@
   icon: { sprite: Objects/Tools/wrench.rsi, state: icon }
 
 - type: tool
+  id: Axing
+  name: tool-quality-axing-name
+  toolName: tool-quality-axing-tool-name
+  spawn: FireAxe
+  icon: { sprite: Objects/Weapons/Melee/fireaxe.rsi, state: icon }
+
+- type: tool
   id: Prying
   name: tool-quality-prying-name
   toolName: tool-quality-prying-tool-name


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Allows the atmospheric technician’s fire axe to pry open plating. The syndicate fireaxe would still not be able to pry fire axe.
Readds https://github.com/RonRonstation/ronstation/pull/45, https://github.com/RonRonstation/ronstation/pull/46, and https://github.com/RonRonstation/ronstation/pull/84.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently, there is no way to pry open plating tiles to turn it into lattice, however, sometimes you need to undo the placement of plating, especially when you did so on mistake.
The atmospheric technician’s fire axe should be given the privilege of being able to pry open plating, not only because of how only qualified engineers can get it (not even technical assistants, interns of engineering, can get it), but because there is currently no way to pry open plating. Besides, it’s the atmospheric technician’s job to fix atmospheric issues.

The syndicate fireaxe will not be able to pry plating, to prevent syndicate operatives from being able to quickly make entire areas uninhabitatable.

This should be either modified, or reverted, whenever a refactor comes that can affect the codebase:
https://github.com/space-wizards/space-station-14/pull/24424#issuecomment-1904992912

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Merrokitsune
- tweak: Atmospheric technician’s fire axe can pry open plating.