### PR TITLE
feat: Reduce unmarked weapons price to 15k

### DIFF
--- a/Resources/Prototypes/_Ronstation/Catalog/Cargo/cargo_smuggled.yml
+++ b/Resources/Prototypes/_Ronstation/Catalog/Cargo/cargo_smuggled.yml
@@ -4,6 +4,6 @@
     sprite: Structures/Machines/bomb.rsi
     state: training-bomb
   product: ArmorySmuggledWeaponry
-  cost: 25000
+  cost: 15000
   category: cargoproduct-category-name-armory
   group: market


### PR DESCRIPTION
## About the PR
Pull request 191 https://github.com/RonRonstation/ronstation/pull/191 was merged on March 5, 2025, offering cargo the ability to gamble and get three random weapons that wouldn't acidify (thank Nar'Sie!). It acts as a sort of "counterweight" against Robin's pull request 196 https://github.com/RonRonstation/ronstation/pull/196, which causes armory and security-locked crates to acidify their contents upon being broken open.

However, with the introduction of the departmental economy, Cargo gets less money from bounties. I am intending to reduce the price of the crate from its current $25k to something more reasonable such as $15k, to make it fairer.

**Changelog**
:cl: Lemuria
- tweak: Reduced unmarked weapons crate price to 15k
