### PR TITLE
remove extended from the secret pool

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,8 +2,8 @@
   id: Secret
   weights:
     Nukeops: 0.20
-    Traitor: 0.55
-    Zombie: 0.05
-    Extended: 0.10 # Ronstation - Survival gamemode is too broken to play regularly. Replaced with extended instead.
-    Revolutionary: 0.05
+    Traitor: 0.50 # Ronstation - Ron rarely reaches the population for gamemodes besides traitors. Reduced the weight of traitors and gave it to other gamemodes.
+    Zombie: 0.1
+    Survival: 0.05 # Ronstation - Survival gamemode is too broken to play regularly. Half of it's weight has been given to other gamemodes instead.
+    Revolutionary: 0.1
     Wizard: 0.05 # Why not, should probably be lower


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
extended has been removed from the gamemode pool

survival has been reintroduced at 50% of it's previous rate

zombies and revs are twice as common as before

traitors is like 9.8% less common
<!-- What did you change? -->

## Why / Balance

extended literally does not function properly without admin intervention, it is *intentionally* designed this way, it *should not* roll naturally

survival, unlike extended, is *not* broken. yes, survival can be quite stressful, but it does *actually function*. stress can be fun sometimes, anyways

the absence of survival also contributes to shifts feeling more quiet then usual

we very rarely have the pop for zombies or revs, so they should be a bit more common, so they're more likely to roll when we *do* have the pop 
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
number -> other number

<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

