### PR TITLE
Adds External access to the default access for Paramedics

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -13,6 +13,7 @@
   access:
   - Medical
   - Maintenance
+  - External
   extendedAccess:
   - Chemistry
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Paramedics now start with external access.

## Why / Balance
People dying in space is a headache for Paramedics. Removes some friction from the job while making them a bit more unique as a medical role that gets externals at the start of the round. 

## Technical details
Changes to the paramedic.yml file in Resources\Prototypes\Roles\Jobs\Medical

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- Tweak: Paramedics now start with external access.


