### PR TITLE
init

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -27,6 +27,7 @@
   - ChiefMedicalOfficer
   - Brig
   - Cryogenics
+  - External
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
CMO now has external access round start.

## Why / Balance
This was missed when adding it to paramedic.

:cl:
- tweak: CMO has external access to coincide with Paramedic getting external access
