### PR TITLE
Removes salt ore deposits from expeditions and lowers the chance of it appearing in asteroids

### DIFF
--- a/Resources/Prototypes/Procedural/Magnet/asteroid_ore_gens.yml
+++ b/Resources/Prototypes/Procedural/Magnet/asteroid_ore_gens.yml
@@ -4,7 +4,7 @@
     OreIron: 1.0
     OreQuartz: 1.0
     OreCoal: 0.33
-    OreSalt: 0.25
+    OreSalt: 0.10
     OreGold: 0.25
     OreSilver: 0.25
     OrePlasma: 0.20

--- a/Resources/Prototypes/Procedural/biome_ore_templates.yml
+++ b/Resources/Prototypes/Procedural/biome_ore_templates.yml
@@ -40,19 +40,19 @@
   maxGroupSize: 12
   radius: 4
 
-- type: biomeMarkerLayer
-  id: OreSalt
-  entityMask:
-    AsteroidRock: AsteroidRockSalt
-    WallRock: WallRockSalt
-    WallRockBasalt: WallRockBasaltSalt
-    WallRockChromite: WallRockChromiteSalt
-    WallRockSand: WallRockSandSalt
-    WallRockSnow: WallRockSnowSalt
-  maxCount: 30
-  minGroupSize: 8
-  maxGroupSize: 12
-  radius: 4
+# - type: biomeMarkerLayer
+#   id: OreSalt
+#   entityMask:
+#     AsteroidRock: AsteroidRockSalt
+#     WallRock: WallRockSalt
+#     WallRockBasalt: WallRockBasaltSalt
+#     WallRockChromite: WallRockChromiteSalt
+#     WallRockSand: WallRockSandSalt
+#     WallRockSnow: WallRockSnowSalt
+#   maxCount: 30
+#   minGroupSize: 8
+#   maxGroupSize: 12
+#   radius: 4
 
 # Medium value
 # Gold

--- a/Resources/Prototypes/Procedural/biome_ore_templates_low.yml
+++ b/Resources/Prototypes/Procedural/biome_ore_templates_low.yml
@@ -40,19 +40,19 @@
   maxGroupSize: 6
   radius: 4
 
-- type: biomeMarkerLayer
-  id: OreSaltLow
-  entityMask:
-    AsteroidRock: AsteroidRockSalt
-    WallRock: WallRockSalt
-    WallRockBasalt: WallRockBasaltSalt
-    WallRockChromite: WallRockChromiteSalt
-    WallRockSand: WallRockSandSalt
-    WallRockSnow: WallRockSnowSalt
-  maxCount: 15
-  minGroupSize: 4
-  maxGroupSize: 6
-  radius: 4
+# - type: biomeMarkerLayer
+#   id: OreSaltLow
+#   entityMask:
+#     AsteroidRock: AsteroidRockSalt
+#     WallRock: WallRockSalt
+#     WallRockBasalt: WallRockBasaltSalt
+#     WallRockChromite: WallRockChromiteSalt
+#     WallRockSand: WallRockSandSalt
+#     WallRockSnow: WallRockSnowSalt
+#   maxCount: 15
+#   minGroupSize: 4
+#   maxGroupSize: 6
+#   radius: 4
 
 # Medium value
 # Gold

--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -134,12 +134,12 @@
     - !type:BiomeMarkerLoot
       proto: OreQuartz
 
-- type: salvageLoot
-  id: OreSalt
-  guaranteed: true
-  loots:
-    - !type:BiomeMarkerLoot
-      proto: OreSalt
+# - type: salvageLoot
+#   id: OreSalt
+#   guaranteed: true
+#   loots:
+#     - !type:BiomeMarkerLoot
+#       proto: OreSalt
 
 # - Medium value
 - type: salvageLoot


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Salt ore deposits should no longer be generated in expeditions, and should be as rare as artifact fragments or bananium in asteroids.

## Why / Balance
The uses for the iodine and table salt produced by grinding salt ore are close to none. In the absence of a future chem rework in which chem must source most of its chemicals from the station, salt ore only exists to be thrown into space or clog up mining bags.

This pull request is being made as the result of a suggestion poll, 12 - 2 for removing the ore.

## Technical details
Commented out relevant lines in biome_ore_templates.yml and biome_ore_templates_low.yml and reduced the weight of OreSalt in asteroid_ore_gens.yml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Salt ore deposits will no longer be generated on expedition maps, and has a much lower chance of appearing in asteroids.

