### PR TITLE
Enrobustify Vox slightly

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -35,13 +35,16 @@
     # This allows Vox to take their mask off temporarily to eat something without needing a trip to medbay afterwards.
     allowedStates:
     - Alive
-    damageCap: 20
+    damageCap: 50
     damage:
       types:
-        Heat: -0.07
+        Heat: -0.06
+        Cold: -0.02
+        Shock: -0.02
         Poison: -0.2 # needs to be less than the PendingZombieComponent does or they never become zombies by the disease.
+        Radiation: -0.02
       groups:
-        Brute: -0.07
+        Brute: -0.06
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -1,4 +1,5 @@
-﻿- type: entity
+﻿# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+- type: entity
   parent: BaseMobSpeciesOrganic
   id: BaseMobVox
   abstract: true
@@ -35,16 +36,18 @@
     # This allows Vox to take their mask off temporarily to eat something without needing a trip to medbay afterwards.
     allowedStates:
     - Alive
+# start of modifications
     damageCap: 50
     damage:
       types:
         Heat: -0.06
         Cold: -0.02
         Shock: -0.02
-        Poison: -0.2 # needs to be less than the PendingZombieComponent does or they never become zombies by the disease.
+        Poison: -0.2 # essentially halves the speed vox turn into romerol zombies. fun
         Radiation: -0.02
       groups:
         Brute: -0.06
+# end of modifications
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:

--- a/Resources/ServerInfo/Guidebook/Mobs/Vox.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Vox.xml
@@ -17,7 +17,7 @@
   In addition to regular foods, Vox can also eat various snack packaging, banana peels, eggshells, and raw meat without any ill effects. They also like to drink welding fuel.
 
   Vox [color=#1e90ff]passively recover more damage types[/color] than other species,
-  Vox also passively recover damage at under [color="31e90ff]50 total points[/color], unlike other species' [color=#ffa500]20 total.[/color]
+  Vox also passively recover damage at under [color=#1e90ff]50 total points[/color], unlike other species' [color=#ffa500]20 total.[/color]
   This allows them to endure breathing in a standard station atmosphere for 90 or so seconds, which takes them roughly 260 seconds to recover from,
   letting them quickly eat, drink, take oral medication, and so on; as well as recovering from miscellaneous damages on their own.
   Vox deal Slash damage with their unarmed attack.

--- a/Resources/ServerInfo/Guidebook/Mobs/Vox.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Vox.xml
@@ -16,13 +16,10 @@
 
   In addition to regular foods, Vox can also eat various snack packaging, banana peels, eggshells, and raw meat without any ill effects. They also like to drink welding fuel.
 
-  Vox [color=#1e90ff]slowly recover from low levels of poison damage[/color] on their own,
-  so long as they are careful not to exceed 20 poison damage.
-  This allows them to endure breathing station air for up to thirty seconds at a time without lasting damage,
-  letting them quickly eat, drink, take oral medication, and so on.
-  A thirty second oxygen exposure takes them two minutes to recover from.
-  If their health does not seem to improve within a minute of oxygen exposure, they should seek medical attention.
-
+  Vox [color=#1e90ff]passively recover more damage types[/color] than other species,
+  Vox also passively recover damage at under [color="31e90ff]50 total points[/color], unlike other species' [color=#ffa500]20 total.[/color]
+  This allows them to endure breathing in a standard station atmosphere for 90 or so seconds, which takes them roughly 260 seconds to recover from,
+  letting them quickly eat, drink, take oral medication, and so on; as well as recovering from miscellaneous damages on their own.
   Vox deal Slash damage with their unarmed attack.
 
 </Document>


### PR DESCRIPTION
## About the PR
Raises Vox passive healing threshold to 50 total damage, up from 20; and adds cold, shock, & radiation damage passive healing.
Updates Vox guidebook entry to reflect these values.

## Why / Balance
Some people who don't play Vox were being spacist to Vox because they have no "advantage" to 'compensate' for O2 toxicity.

## Technical details
6 lines of yaml changes. Rewritten paragraph in guidebook xaml.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Vox now regenerate more damage types, below 50 total damage.