### PR TITLE
Make tourniquets actually good and useful and accessible 

### DIFF
--- a/Resources/Locale/en-US/stack/stacks.ftl
+++ b/Resources/Locale/en-US/stack/stacks.ftl
@@ -117,6 +117,7 @@ stack-inflatable-door = inflatable door
 stack-ointment = ointment
 stack-aloe-cream = aloe cream
 stack-gauze = gauze
+stack-tourniquet = tourniquet
 stack-brutepack = brutepack
 stack-bloodpack = bloodpack
 stack-medicated-suture = medicated-suture

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -296,6 +296,7 @@
   parent: BaseHealingItem
   id: Tourniquet
   name: tourniquet
+  suffix: Full
   description: Stops bleeding! Hopefully.
   components:
     - type: Tag
@@ -310,11 +311,12 @@
         - Biological
       damage:
         groups:
-          Brute: 5 # Tourniquets HURT!
         types:
-          Asphyxiation: 5 # Essentially Stopping all blood reaching a part of your body
-      bloodlossModifier: -10 # Tourniquets stop bleeding
-      delay: 0.5
+          Slash: -2
+          Piercing: -2
+      bloodlossModifier: -5 # stops bleeding. sort of!
+      delay: 2
+      selfHealPenaltyMultiplier: 2 # helping yourself isn't as hard as other topicals
       healingBeginSound:
         path: "/Audio/Items/Medical/brutepack_begin.ogg"
         params:
@@ -325,6 +327,17 @@
         params:
           volume: 1.0
           variation: 0.125
+    - type: Stack
+      stackType: Tourniquet
+      count: 5
+
+- type: entity
+  parent: Tourniquet
+  suffix: Single
+  id: Tourniquet1
+  components:
+  - type: Stack
+    count: 1
 
 - type: entity
   name: roll of gauze

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -9,6 +9,7 @@
   - TargetClown
   - TargetHuman
   - TargetSyndicate
+  - Tourniquet
   - Zipties
 
 # Practice ammo/mags and practice weapons

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -198,6 +198,15 @@
     Plastic: 200
     Steel: 100
 
+- type: latheRecipe
+  parent: BaseToolRecipe
+  id: Tourniquet
+  result: Tourniquet1
+  completetime: 1.5
+  materials:
+    Plastic: 25
+    Steel: 10
+
 ## Weapons
 
 # Melee

--- a/Resources/Prototypes/Stacks/medical_stacks.yml
+++ b/Resources/Prototypes/Stacks/medical_stacks.yml
@@ -20,6 +20,13 @@
   maxCount: 10
 
 - type: stack
+  id: Tourniquet
+  name: stack-tourniquet
+  icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: tourniquet}
+  spawn: Tourniquet
+  maxCount: 5
+
+- type: stack
   id: Brutepack
   name: stack-brutepack
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: gauze }


### PR DESCRIPTION
## About the PR
Before, tourniquets sucked ass and could literally kill you. Not anymore.

Tourniquets now heal 2 slash & 2 piercing, take away 5 points of bleeding (of 10 total possible), take 2 seconds to apply to another and 4 seconds to apply to yourself, and stack up to 5.
The security techfab can now manufacture 1 tourniquet for 0.1 steel and 0.25 plastic.
This is changed from:
Tourniquets _dealing_ 5 of all brute (????!!) and 5 asphyxiation, taking away 10 points of bleeding, taking 0.5 seconds to apply to another and 1.5 seconds to apply to yourself, and not stacking at all.
Tourniquets being obtainable only as randomized table/locker clutter and in the SecTech vending machine.

## Why / Balance
Tourniquets were a laughably bad ""feature"" that nobody ever, ever, _ever_ interacts with. The only purpose they served was to exist as table clutter and kill cadets who didn't know better. This pull request rectifies that and makes tourniquets a viable emergency medical tool, and makes them more obtainable in tandem.

Tourniquets heal minimal damage, stop bleeding _mostly_, and apply rapidly. This cements their use as exclusively emergency bleeding stoppers, being impractical for general healing. They stack less than other topicals, necessitating more frequent restocking & seeking outside medical attention. The increased delay serves to provide reaction time to stop application once bleeding is stopped.
In some (many) cases you must use 2 tourniquets to stop bleeding entirely, this is still better than hitting yourself with a lighter, but isn't a roll of gauze or a suture.
## Technical details
<!-- Summary of code changes for easier review. -->
yaml changes to tourniquets, new stacking prototype in yaml, tiny lathe recipe yaml additions.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: arenaconspiracy
- tweak: tourniquets are actually useful now
- tweak: the security techfab can now produce tourniquets for cheap