### PR TITLE
Raise bluespace syringe maximum injection

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -544,6 +544,7 @@
   - type: Injector
     delay: 2.5
     injectOnly: false
+    maxTransferAmount: 25
   - type: SolutionContainerVisuals
     maxFillLevels: 2
     fillBaseName: syringe


### PR DESCRIPTION
## About the PR
Raises bluespace syringe maximum injection capacity from 15 units to 25.

## Why / Balance
The bluespace syringe, with an identical injection rate to the basic syringe, serves only as an extremely niche chemical storage method. This gives it a second practical advantage.

## Technical details
One (1) line change in yaml.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Bluespace syringes can now inject 25 units of reagent at a time