### PR TITLE
5-07 Paradoxical Existence space law criminal charge

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
@@ -253,6 +253,7 @@
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
+	Paradoxical Existence
       </Box>
     </ColorBox>
     <ColorBox>
@@ -923,6 +924,26 @@
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         5-06
+      </Box>
+    </ColorBox>
+    <ColorBox>
+      <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
+        Paradoxical Existence
+      </Box>
+    </ColorBox>
+    <ColorBox>
+      <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
+        To create or perpetuate a spacetime paradox by mere existence.
+      </Box>
+    </ColorBox>
+    <ColorBox>
+      <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
+        Containment is reccomended over execution unless there is absolute certainty over the nature of the offender. Clones made by spacetime paradoxes usually explosively solve themselves after a period of time.
+      </Box>
+    </ColorBox>
+    <ColorBox>
+      <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
+	5-07
       </Box>
     </ColorBox>
   </Table>


### PR DESCRIPTION
## About the PR
Adds 5-07 Paradoxical Existence criminal charge to space law, pending rework of paradox clones.

## Why / Balance
In a paradox situation, the original character has very few counterplays to a hostile clone. If you fight back you are assumed to be the clone, getting distance from a clone is often infeasible, et cetera. This pull request adds an in-character avenue for paradox clone counterplays, pending a rework of paradox clones where they are not categorically hostile.
It is currently much, much more fun to role abandon as a paradox clone, ignoring your sole kill objective, but that is another issue, pending a rework and separate PR.

## Technical details
Additions to one xml guidebook file.

## Media
![image](https://github.com/user-attachments/assets/4932aed2-c29b-4051-8712-625284ccf684)
![image](https://github.com/user-attachments/assets/844222a1-7de7-4b80-b6b8-8c0e32010db6)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Space Law now features a 5-07 Paradoxical Existence criminal charge