### PR TITLE
Make steel-cap logs and glasstles recyclable

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 # When adding new food also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\food_produce.yml
 # For produce that can't be immediately eaten
 
@@ -205,9 +207,9 @@
   - type: Item
     heldPrefix: produce
   - type: SolutionContainerManager
-  - type: PhysicalComposition
-    materialComposition:
-      Steel: 100
+  - type: PhysicalComposition # modified by Ronstation contributor(s)
+    materialComposition: # modified by Ronstation contributor(s)
+      Steel: 100 # modified by Ronstation contributor(s)
   - type: MeleeWeapon
     damage:
       types:
@@ -1772,9 +1774,9 @@
         reagents:
         - ReagentId: Razorium
           Quantity: 15
-  - type: PhysicalComposition
-    materialComposition:
-      Glass: 100
+  - type: PhysicalComposition # modified by Ronstation contributor(s)
+    materialComposition: # modified by Ronstation contributor(s)
+      Glass: 100 # modified by Ronstation contributor(s)
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/glasstle.rsi
   - type: Produce


### PR DESCRIPTION
## About the PR
Makes steel-cap logs and glasstles recyclable, adding a faster way to get the materials from them.

## Why / Balance
A frequent botany player asked for it. And the implications are funny.

## Technical details
Adds PhysicalCompositionComponent to the glasstle and steel-cap log prototypes.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Glasstles & steel-cap logs now get ground in the recycler