### PR TITLE
Adds a toy version of the double bladed energy sword

### DIFF
--- a/Resources/Locale/en-US/recipes/tags.ftl
+++ b/Resources/Locale/en-US/recipes/tags.ftl
@@ -78,6 +78,7 @@ construction-graph-tag-rubber-ducky = a rubber ducky
 construction-graph-tag-ghost = ghost soft toy
 construction-graph-tag-ectoplasm = ectoplasm
 construction-graph-tag-lizard-plushie = lizard plushie
+construction-graph-tag-toy-sword = toy sword
 
 # carpet
 construction-graph-tag-black-carpet = black carpet

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1732,6 +1732,9 @@
     - type: Item
       size: Small
       sprite: Objects/Weapons/Melee/e_sword-inhands.rsi
+    - type: Tag
+      tags:
+        - ToySword
     - type: UseDelay
       delay: 1.0
     - type: PointLight
@@ -1773,6 +1776,54 @@
         path: /Audio/Weapons/eblademiss.ogg
         params:
           variation: 0.125
+
+- type: entity
+  name: toy double-bladed energy sword
+  parent: ToySword
+  id: EnergySwordDoubleToy
+  description: Syndicate Command Interns thought that having one blade on the energy sword was not enough. This can be stored in pockets.
+  components:
+  - type: ItemToggle
+    predictable: false # audio prediction bugged with some energy weapons
+    onUse: false # wielding events control it instead
+    onActivate: false # prevents the weapon from being able to be turned on when it is on the ground
+    soundActivate:
+      path: /Audio/Weapons/ebladeon.ogg
+      params:
+        volume: 3
+    soundDeactivate:
+      path: /Audio/Weapons/ebladeoff.ogg
+      params:
+        volume: 3
+  - type: ItemToggleActiveSound
+    activeSound:
+      path: /Audio/Weapons/ebladehum.ogg
+      params:
+        volume: 3
+  - type: Wieldable
+    wieldSound: null # esword light sound instead
+  - type: MeleeWeapon
+    wideAnimationRotation: -135
+    attackRate: 1.5
+    angle: 100
+    damage:
+      types:
+        Blunt: 0
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/e_sword_double.rsi
+    layers:
+      - state: e_sword_double
+      - state: e_sword_double_blade
+        color: "#FFFFFF"
+        visible: false
+        shader: unshaded
+        map: [ "blade" ]
+  - type: Item
+    size: Small
+    sprite: Objects/Weapons/Melee/e_sword_double-inhands.rsi
+  - type: Construction
+    graph: ToyDoubleBladedEsword
+    node: toydoublebladedesword
 
 - type: entity
   parent: BasePlushie

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1781,7 +1781,7 @@
   name: toy double-bladed energy sword
   parent: ToySword
   id: EnergySwordDoubleToy
-  description: Syndicate Command Interns thought that having one blade on the energy sword was not enough. This can be stored in pockets.
+  description: Sandy-Cat might have discontinued the 'official' toy version of the twin-blade, but that won't stop you from tying two toy swords together and having a blast!
   components:
   - type: ItemToggle
     predictable: false # audio prediction bugged with some energy weapons

--- a/Resources/Prototypes/Recipes/Construction/Graphs/fun/toy_double_bladed_esword.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/fun/toy_double_bladed_esword.yml
@@ -1,0 +1,25 @@
+- type: constructionGraph
+  id: ToyDoubleBladedEsword
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: toydoublebladedesword
+          steps:
+            - tag: ToySword
+              name: construction-graph-tag-toy-sword
+              icon:
+                sprite: Objects/Weapons/Melee/e_sword.rsi
+                state: icon
+              doAfter: 5
+            - tag: ToySword
+              name: construction-graph-tag-toy-sword
+              icon:
+                sprite: Objects/Weapons/Melee/e_sword.rsi
+                state: icon
+              doAfter: 5
+            - material: Cable
+              amount: 5
+              doAfter: 5
+    - node: toydoublebladedesword
+      entity: EnergySwordDoubleToy

--- a/Resources/Prototypes/Recipes/Construction/fun.yml
+++ b/Resources/Prototypes/Recipes/Construction/fun.yml
@@ -5,3 +5,11 @@
   targetNode: bananiumHorn
   category: construction-category-weapons
   objectType: Item
+
+- type: construction
+  id: ToyDoubleBladedEsword
+  graph: ToyDoubleBladedEsword
+  startNode: start
+  targetNode: toydoublebladedesword
+  category: construction-category-weapons
+  objectType: Item

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1384,6 +1384,9 @@
   id: ToySidearm
 
 - type: Tag
+  id: ToySword
+
+- type: Tag
   id: Trash
 
 - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a toy version of the double-bladed esword, obtainable by combining two regular toy swords with some lv-cables.

## Why / Balance
Mostly because I think its a fun idea, and it makes use of the sprites and such made for the double-bladed sword without doing anything crazy to the game balance.

## Technical details
Adds some prototypes to .yml files, a tag to the toysword so that it can be used in a construction graph for the double-bladed toy sword.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Added a toy version of the double-bladed energy sword, obtainable by combining two toy swords using some lv cables.

