### PR TITLE
Outer clothing & pertinent fixes

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 - type: cargoProduct
   id: CargoOreBox
   icon:
@@ -8,6 +10,7 @@
   category: cargoproduct-category-name-cargo
   group: market
 
+# start of modifications
 - type: cargoProduct
   id: cargoJetpack
   icon:
@@ -47,13 +50,14 @@
   cost: 10000
   category: cargoproduct-category-name-cargo
   group: market
+# end of modifications
 
 - type: cargoProduct
   id: CargoLuxuryHardsuit
   icon:
     sprite: Clothing/Head/Hardsuits/luxury.rsi
     state: icon
-  product: SuitStorageLuxury
+  product: SuitStorageLuxury # Ronstation
   cost: 15000
   category: cargoproduct-category-name-cargo
   group: market

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/backpack.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 - type: entity
   parent: ClothingBackpackSyndicate
   id: ClothingBackpackSyndicateBundle
@@ -19,6 +21,7 @@
     - id: ClothingMaskGasSyndicate
     - id: ClothingHandsGlovesCombat
 
+# start of modifications
 - type: entity
   parent: ClothingBackpackSyndicateBundle
   id: ClothingBackpackSyndicateEVABundle
@@ -33,4 +36,4 @@
       - id: ClothingHandsGlovesColorYellowBudget
       - id: DoubleEmergencyOxygenTankFilled
       - id: DoubleEmergencyNitrogenTankFilled
-
+# end of modifications

--- a/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 - type: entity
   id: CrateEmergencyExplosive
   parent: CrateSecgear
@@ -87,6 +89,7 @@
       - id: NitrogenTankFilled
         amount: 4
 
+# start of modifications
 - type: entity
   id: CrateEVASuitsBasic
   parent: CrateInternals
@@ -116,12 +119,13 @@
         amount: 3
       - id: OxygenTankFilled
         amount: 3
+# end of modifications
 
 - type: entity
   id: CrateEmergencyRadiation
   parent: CrateRadiation
   name: radiation protection crate
-  description: Survive the Nuclear Apocalypse and Singuloose alike with two sets of Radiation suits. Each set contains a helmet, suit, and Geiger counter. We'll even throw in a bottle of vodka and some glasses too, considering the life-expectancy of people who order this.
+  description: Survive the Nuclear Apocalypse and Singularity engine alike with two sets of Radiation suits. Each set contains a helmet, suit, and Geiger counter. We'll even throw in a bottle of vodka and some glasses too, considering the life-expectancy of people who order this.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 - type: entityTable
   id: FillSalvageSpecialistHardsuitSpatio
   table: !type:AllSelector
@@ -5,10 +7,11 @@
     - id: NitrogenTankFilled
     - id: OxygenTankFilled
     - id: ClothingShoesBootsMag
-    - id: ClothingShoesBootsSalvage
+    - id: ClothingShoesBootsSalvage # Ronstation
     - id: ClothingOuterHardsuitSpatio
     - id: ClothingMaskGasExplorer
 
+# start of modifications
 - type: entityTable
   id: FillMiningHardsuitGear
   table: !type:AllSelector
@@ -33,6 +36,7 @@
     - id: ClothingMaskGasExplorer
     - id: Pickaxe
     - id: ClothingNeckBling
+# end of modifications
 
 - type: entityTable
   id: LockerFillSalvageSpecialist

--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 - type: entity
   id: LockerSyndicatePersonalFilled
   suffix: Filled
@@ -15,6 +17,7 @@
         - id: ClothingHeadsetAltSyndicate
         - id: ClothingEyesHudSyndicate
 
+# start of modifications
 - type: entityTable
   id: FillLockerEmergencyStandard
   table: !type:AllSelector
@@ -38,6 +41,7 @@
       prob: 0.1
     - id: BoxMRE
       prob: 0.1
+# end of modifications
 
 - type: entity
   id: ClosetEmergencyFilledRandom
@@ -59,6 +63,7 @@
       entity_storage: !type:NestedSelector
         tableId: FillLockerEmergencyStandard
 
+# start of modifications
 - type: entityTable
   id: FillLockerEmergencyN2Standard
   table: !type:AllSelector
@@ -78,6 +83,7 @@
       prob: 0.1
     - id: BoxMRE
       prob: 0.1
+# end of modifications
 
 - type: entity
   id: ClosetEmergencyN2FilledRandom

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -4,6 +4,7 @@
 #Basic EVA
 - type: entity
   id: SuitStorageEVA
+  name: EVA suit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: EVA
   components:
@@ -18,6 +19,7 @@
 #Basic EVA (Big Ass Helmet)
 - type: entity
   id: SuitStorageEVAAlternate
+  name: EVA suit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: EVA, Large Helmet
   components:
@@ -32,6 +34,7 @@
 #Emergency EVA
 - type: entity
   id: SuitStorageEVAEmergency
+  name: emergency EVA suit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: Emergency EVA
   components:
@@ -45,6 +48,7 @@
 #Prisoner EVA
 - type: entity
   id: SuitStorageEVAPrisoner
+  name: prisoner EVA suit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: Prisoner EVA
   components:
@@ -59,6 +63,7 @@
 #Syndicate EVA
 - type: entity
   id: SuitStorageEVASyndicate
+  name: syndicate EVA suit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: Syndicate EVA
   components:
@@ -73,6 +78,7 @@
 #Pirate EVA
 - type: entity
   id: SuitStorageEVAPirate
+  name: pirate EVA suit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: Pirate EVA
   components:
@@ -86,6 +92,7 @@
 #NTSRA Voidsuit
 - type: entity
   id: SuitStorageNTSRA
+  name: NTSRA suit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: Ancient EVA
   components:
@@ -100,6 +107,7 @@
 #Engineering hardsuit
 - type: entity
   id: SuitStorageEngi
+  name: engineering hardsuit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: Station Engineer
   components:
@@ -113,6 +121,7 @@
 #Atmospherics hardsuit
 - type: entity
   id: SuitStorageAtmos
+  name: atmospheric hardsuit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: Atmospheric Technician
   components:
@@ -126,6 +135,7 @@
 #Security hardsuit
 - type: entity
   id: SuitStorageSec
+  name: security hardsuit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: Security
   components:
@@ -141,6 +151,7 @@
 #CE's hardsuit
 - type: entity
   id: SuitStorageCE
+  name: chief engineer's hardsuit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: Chief Engineer
   components:
@@ -154,6 +165,7 @@
 #CMO's hardsuit
 - type: entity
   id: SuitStorageCMO
+  name: chief medical officer's hardsuit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: Chief Medical Officer
   components:
@@ -167,6 +179,7 @@
 #RD's hardsuit
 - type: entity
   id: SuitStorageRD
+  name: research director's hardsuit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: Research Director
   components:
@@ -180,6 +193,7 @@
 #HOS's hardsuit
 - type: entity
   id: SuitStorageHOS
+  name: head of security's hardsuit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: Head of Security
   components:
@@ -193,6 +207,7 @@
 #Warden's hardsuit
 - type: entity
   id: SuitStorageWarden
+  name: warden's hardsuit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: Warden
   components:
@@ -208,6 +223,7 @@
 #Captain's hardsuit
 - type: entity
   id: SuitStorageCaptain
+  name: captain's hardsuit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: Captain
   components:
@@ -221,7 +237,7 @@
 #Salvage hardsuit
 - type: entity
   id: SuitStorageSalv
-  name: spationaut suit storage
+  name: spationaut hardsuit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: Salvage
   components:
@@ -235,7 +251,7 @@
 #Mining hardsuit
 - type: entity
   id: SuitStorageMining
-  name: mining suit storage
+  name: mining hardsuit storage unit # Ronstation
   description: A suit storage unit containing a mining hardsuit, air tanks, footwear, and a spare pickaxe.
   parent: SuitStorageBase
   suffix: Salvage
@@ -247,10 +263,11 @@
     - type: AccessReader
       access: [["Salvage"]]
 
+# start of modifications
 #Luxury hardsuit
 - type: entity
   id: SuitStorageLuxury
-  name: luxury mining suit storage
+  name: luxury mining hardsuit storage unit
   description: A suit storage unit containing a luxury mining hardsuit, amenities for it, and a declaration of your wealth to go around your neck.
   parent: SuitStorageBase
   suffix: Salvage, DO NOT MAP
@@ -261,10 +278,13 @@
           tableId: FillLuxuryHardsuitGear
     - type: AccessReader
       access: [["Salvage"]]
+# end of modifications
 
 #Blood-red hardsuit
 - type: entity
   id: SuitStorageSyndie
+  name: blood-red hardsuit storage unit # Ronstation
+  description: Not actually blood red..... The suit inside is. # Ronstation
   parent: SuitStorageBase
   suffix: Syndicate Hardsuit
   components:
@@ -279,6 +299,7 @@
 #Pirate Captain's hardsuit
 - type: entity
   id: SuitStoragePirateCap
+  name: pirate captain's hardsuit storage unit # Ronstation
   parent: SuitStorageBase
   suffix: Pirate Captain
   components:
@@ -292,6 +313,8 @@
 #Wizard
 - type: entity
   id: SuitStorageWizard
+  name: wizard hardsuit storage unit # Ronstation
+  description: Due to budget cuts in the wizard's federation, doesn't actually come with a hardsuit. # Ronstation
   parent: SuitStorageBase
   suffix: Wizard
   components:
@@ -301,5 +324,6 @@
         - id: OxygenTankFilled
         - id: ClothingMaskBreath
         # TODO: Gone until reworked to have no space protection
+        # FUCKYOU: then maybe null it in the migration file????? idiot. - Ronstation contributor
         #- id: ClothingOuterHardsuitWizard
         #- id: JetpackVoidFilled

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 # TODO: make more categories
 # Guns
 
@@ -1708,7 +1710,7 @@
   name: uplink-eva-syndie-name
   description: uplink-eva-syndie-desc
   icon: { sprite: /Textures/Clothing/OuterClothing/Suits/eva_syndicate.rsi, state: icon }
-  productEntity: ClothingBackpackSyndicateEVABundle
+  productEntity: ClothingBackpackSyndicateEVABundle # Ronstation
   discountCategory: rareDiscounts
   discountDownTo:
     Telecrystal: 1

--- a/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 #EVA Helmet
 - type: entity
   parent: ClothingHeadEVAHelmetBase
@@ -63,7 +65,7 @@
   parent: ClothingHeadEVAHelmetBase
   id: ClothingHeadHelmetAncient
   name: NTSRA void helmet
-  description: An antique design of helmet made by the Nanotrasen Space Research Association. You can't tell if this is one of the old ones, or just a reproduction.
+  description: An antique design of helmet made by the Nanotrasen Space Research Association. You can't tell if this is one of the old ones, or just a reproduction. # Ronstation
   components:
   - type: Sprite
     sprite: Clothing/Head/Helmets/ancientvoidsuit.rsi

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 #When adding new hardsuits, please try to keep the organization consistent with hardsuit.yml (if possible.)
 
 #For now, since locational damage is not a thing, all "combat" hardsuits (with the exception of the deathsquad hardsuit) have the equvilent of a helmet in terms of armor.
@@ -145,7 +147,7 @@
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSalvage
   name: mining hardsuit helmet
-  description: A helmet for hard working miners. Comes with basic armor for explosions & wildlife encounters, and dual floodlights to light up your mineshaft.
+  description: A helmet for hard working miners. Comes with basic armor for explosions & wildlife encounters, and dual floodlights to light up your mineshaft. # Ronstation
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/salvage.rsi
@@ -157,7 +159,7 @@
   - type: PointLight
     radius: 7
     energy: 3
-    color: "#FFFF90"
+    color: "#FFFF90" # Ronstation
   - type: Tag
     tags:
     - CorgiWearable
@@ -297,7 +299,7 @@
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitWarden
   name: warden's hardsuit helmet
-  description: A heavily modified riot helmet. Oddly comfortable for a wearable brick wall.
+  description: A heavily modified riot helmet. Oddly comfortable for a wearable brick wall. # Ronstation
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/security-warden.rsi
@@ -442,7 +444,7 @@
   - type: PointLight
     radius: 10
     energy: 4
-    color: "#FFFF20"
+    color: "#FFFF20" # Ronstation
 
 #ANTAG HARDSUITS
 #Blood-red Hardsuit

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 # Numbers for armor here largely taken from /tg/.
 # armor.yml covers both armored vests (e.g. not just cosmetic) and armor that covers multiple bodyparts/limbs
 
@@ -14,10 +16,10 @@
     sprite: Clothing/OuterClothing/Armor/security.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Armor/security.rsi
-  - type: Item
-    size: Large
-    shape:
-    - 0,0,1,2
+  - type: Item # Ronstation
+    shape: # Ronstation
+    - 0,0,1,2 # Ronstation
+              # ^ this is legally dubious at best
   - type: Armor #Based on /tg/ but slightly compensated to fit the fact that armor stacks in SS14.
     modifiers:
       coefficients:
@@ -61,9 +63,9 @@
     sprite: Clothing/OuterClothing/Armor/bulletproof.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Armor/bulletproof.rsi
-  - type: Item
-    shape:
-    - 0,0,2,2
+  - type: Item # Ronstation
+    shape: # Ronstation
+    - 0,0,2,2 # Ronstation
   - type: Armor
     modifiers:
       coefficients:
@@ -84,10 +86,9 @@
     sprite: Clothing/OuterClothing/Armor/armor_reflec.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Armor/armor_reflec.rsi
-  - type: Item
-    size: Large
-    shape:
-    - 0,0,2,2
+  - type: Item # Ronstation
+    shape: # Ronstation
+    - 0,0,2,2 # Ronstation
   - type: Armor
     modifiers:
       coefficients:
@@ -171,10 +172,9 @@
     sprite: Clothing/OuterClothing/Vests/webvest.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Vests/webvest.rsi
-  - type: Item
-    size: Large
-    shape:
-    - 0,0,1,2
+  - type: Item # Ronstation
+    shape: # Ronstation
+    - 0,0,1,2 # Ronstation
   - type: Armor
     modifiers:
       coefficients:
@@ -198,10 +198,9 @@
     sprite: Clothing/OuterClothing/Vests/elitevest.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Vests/elitevest.rsi
-  - type: Item
-    size: Large
-    shape:
-    - 0,0,1,2
+  - type: Item # Ronstation
+    shape: # Ronstation
+    - 0,0,1,2 # Ronstation
   - type: TemperatureProtection
     heatingCoefficient: 0.1
     coolingCoefficient: 0.1
@@ -232,10 +231,9 @@
     sprite: Clothing/OuterClothing/Vests/mercwebvest.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Vests/mercwebvest.rsi
-  - type: Item
-    size: Large
-    shape:
-    - 0,0,1,2
+  - type: Item # Ronstation
+    shape: # Ronstation
+    - 0,0,1,2 # Ronstation
   - type: Armor
     modifiers:
       coefficients:
@@ -263,10 +261,10 @@
       shader: unshaded
   - type: Clothing
     sprite: Clothing/OuterClothing/Armor/syndie-raid.rsi
-  - type: Item
-    size: Large
-    shape:
-    - 0,0,2,3
+  - type: Item # Ronstation
+    size: Large # Ronstation
+    shape: # Ronstation
+    - 0,0,2,3 # Ronstation
   - type: Armor
     modifiers:
       coefficients:
@@ -340,10 +338,10 @@
     sprite: Clothing/OuterClothing/Armor/riot.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Armor/riot.rsi
-  - type: Item
-    size: Large
-    shape:
-    - 0,0,2,2
+  - type: Item # Ronstation
+    size: Large # Ronstation
+    shape: # Ronstation
+    - 0,0,2,2 # Ronstation
   - type: Armor
     modifiers:
       coefficients:
@@ -366,10 +364,10 @@
     sprite: Clothing/OuterClothing/Armor/cult_armour.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Armor/cult_armour.rsi
-  - type: Item
-    size: Large
-    shape:
-    - 0,0,1,2
+  - type: Item # Ronstation
+    size: Large # Ronstation
+    shape: # Ronstation
+    - 0,0,2,3 # Ronstation
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 - type: entity
   parent: ClothingOuterStorageBase
   id: ClothingOuterCoatBomber
@@ -19,9 +21,9 @@
     sprite: Clothing/OuterClothing/Coats/detective.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Coats/detective.rsi
-  - type: Item
-    shape:
-    - 0,0,1,2
+  - type: Item # Ronstation
+    shape: # Ronstaiton
+    - 0,0,1,2 # Ronstation
   - type: StorageFill
     contents:
     - id: SmokingPipeFilledTobacco
@@ -76,9 +78,9 @@
         Caustic: 0.75 # not the full 90% from ss13 because of the head
   - type: ExplosionResistance
     damageCoefficient: 0.9
-  - type: Item
-    shape:
-    - 0,0,1,2
+  - type: Item # Ronstation
+    shape: # Ronstation
+    - 0,0,1,2 # Ronstation
 
 - type: entity
   abstract: true
@@ -95,9 +97,9 @@
         Caustic: 0.9
   - type: ExplosionResistance
     damageCoefficient: 0.9
-  - type: Item
-    shape:
-    - 0,0,1,2
+  - type: Item # Ronstation
+    shape: # Ronstation
+    - 0,0,1,2 # Ronstation
 
 - type: entity
   parent: [ClothingOuterArmorHoS, ClothingOuterStorageBase, BaseSecurityCommandContraband]

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 #When adding new hardsuits, please try to keep the organization consistent with hardsuit-helmets.yml (if possible.)
 
 #CREW HARDSUITS
@@ -84,7 +86,7 @@
   parent: [ClothingOuterHardsuitBase, BaseCargoContraband]
   id: ClothingOuterHardsuitSpatio
   name: spationaut hardsuit
-  description: A lightweight hardsuit designed for industrial EVA applications, a salvage specialist's best friend.
+  description: A lightweight hardsuit designed for industrial EVA applications, a salvage specialist's best friend. # Ronstation
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/spatio.rsi
@@ -99,7 +101,7 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Radiation: 0.7
+        Radiation: 0.7 # Ronstation
         Caustic: 0.8
   - type: ClothingSpeedModifier
     walkModifier: 0.8
@@ -119,7 +121,7 @@
   parent: [ClothingOuterHardsuitBase, BaseCargoContraband]
   id: ClothingOuterHardsuitSalvage
   name: mining hardsuit
-  description: A hardsuit built for rock crushers and alien robusters. Comes with a brighter light so you can see better when mining, and robusting.
+  description: A hardsuit built for rock crushers and alien robusters. Comes with a brighter light so you can see better when mining, and robusting. # Ronstation
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/salvage.rsi
@@ -132,6 +134,7 @@
     damageCoefficient: 0.7
   - type: Armor
     modifiers:
+# start of modifications
       coefficients:
         Blunt: 0.7
         Slash: 0.6
@@ -139,6 +142,7 @@
         Heat: 0.7
         Radiation: 0.5
         Caustic: 0.8
+# end of modifications
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
@@ -165,6 +169,7 @@
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
+# start of modifications
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: Armor
@@ -176,6 +181,7 @@
         Heat: 0.6
         Radiation: 0.65
         Caustic: 0.5
+# end of modifications
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -292,7 +298,7 @@
   parent: [ClothingOuterHardsuitBase, BaseSecurityContraband]
   id: ClothingOuterHardsuitWarden
   name: warden's hardsuit
-  description: Generations of designs originally tracing from "void cabable riot gear" have produced a frightening hardsuit that lets you REALLY put your foot down and hold your ground.
+  description: Generations of designs originally tracing from "void cabable riot gear" have produced a frightening hardsuit that lets you REALLY put your foot down and hold your ground. # Ronstation
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/security-warden.rsi
@@ -301,6 +307,7 @@
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
+# start of modifications
   - type: ExplosionResistance
     damageCoefficient: 0.3
   - type: Armor
@@ -313,6 +320,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.6
     sprintModifier: 0.6
+# end of modifications
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWarden
@@ -398,7 +406,7 @@
   parent: [ClothingOuterHardsuitBase, BaseCommandContraband]
   id: ClothingOuterHardsuitMedical
   name: chief medical officer's hardsuit
-  description: A lightweight void-capable suit issued to the CMO, Built with advanced fabrics with laceration and chemical protection, that feel soft and don't slow you down!
+  description: A lightweight void-capable suit issued to the CMO, Built with advanced fabrics with laceration and chemical protection, that feel soft and don't slow you down! # Ronstation
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/medical.rsi
@@ -409,12 +417,14 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
+# start of modifications
       coefficients:
         Blunt: 0.7
         Slash: 0.7
         Heat: 0.5
         Radiation: 0.45
         Caustic: 0.1
+# end of modifications
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.4
   - type: ClothingSpeedModifier
@@ -512,7 +522,7 @@
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitLuxury #DO NOT MAP - https://github.com/space-wizards/space-station-14/pull/19738#issuecomment-1703486738
   name: luxury mining hardsuit
-  description: A refurbished mining hardsuit with a new coat of paint and added bling. Comes with improved armor plating more resistant to gibtonite explosions.
+  description: A refurbished mining hardsuit with a new coat of paint and added bling. Comes with improved armor plating more resistant to gibtonite explosions. # Ronstation
   categories: [ DoNotMap ]
   components:
   - type: Sprite
@@ -522,6 +532,7 @@
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
+# start of modifications
   - type: ExplosionResistance
     damageCoefficient: 0.35
   - type: Armor
@@ -536,6 +547,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
+# end of modifications
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitLuxury
@@ -553,7 +565,7 @@
   - type: Item
     size: Huge
     shape:
-    - 0,0,4,4
+    - 0,0,4,4 # Ronstation
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/syndicate.rsi
   - type: PressureProtection
@@ -640,7 +652,7 @@
   - type: Item
     size: Huge
     shape:
-    - 0,0,4,4
+    - 0,0,4,4 # Ronstation
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 #Basic EVA
 - type: entity
   parent: ClothingOuterEVASuitBase
@@ -9,10 +11,9 @@
     sprite: Clothing/OuterClothing/Suits/eva.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/eva.rsi
-  - type: Item
-    size: Large
-    shape:
-    - 0,0,2,3
+  - type: Item # Ronstation
+    shape: # Ronstation
+    - 0,0,2,3 # Ronstation
   - type: Tag
     tags:
     - SuitEVA
@@ -20,6 +21,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
+# start of modifications
 - type: entity
   parent: BaseItem
   id: SuitEVAPackage
@@ -38,6 +40,7 @@
     - id: ClothingOuterHardsuitEVA
     sound:
       path: /Audio/Effects/unwrap.ogg
+# end of modifications
 
 #Syndicate EVA
 - type: entity
@@ -50,9 +53,9 @@
     sprite: Clothing/OuterClothing/Suits/eva_syndicate.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/eva_syndicate.rsi
-  - type: Item
-    shape:
-    - 0,0,2,3
+  - type: Item # Ronstation
+    shape: # Ronstation
+    - 0,0,2,3 # Ronstation
   - type: Tag
     tags:
     - SuitEVA
@@ -61,6 +64,7 @@
   - type: StaticPrice
     price: 1000 # Helmet is 500
 
+# start of modifications
 - type: entity
   parent: SuitEVAPackage
   id: SuitEVAPackageSyndicate
@@ -71,7 +75,7 @@
   - type: SpawnItemsOnUse
     items:
     - id: ClothingOuterEVASuitSyndicate
-
+# end of modifications
 
 #Emergency EVA
 - type: entity
@@ -103,6 +107,7 @@
     - MonkeyWearable
     - WhitelistChameleon
 
+# start of modifications
 - type: entity
   parent: SuitEVAPackage
   id: SuitEmergencyPackage
@@ -117,6 +122,7 @@
   - type: SpawnItemsOnUse
     items:
     - id: ClothingOuterSuitEmergency
+# end of modifications
 
 #Prisoner EVA
 - type: entity
@@ -129,16 +135,13 @@
     sprite: Clothing/OuterClothing/Suits/eva_prisoner.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/eva_prisoner.rsi
-  - type: Item
-    size: Large
-    shape:
-    - 0,0,2,3
   - type: Tag
     tags:
     - SuitEVA
     - MonkeyWearable
     - WhitelistChameleon
 
+# start of modifications
 - type: entity
   parent: SuitEmergencyPackage
   id: SuitPrisonerPackage
@@ -149,14 +152,14 @@
   - type: SpawnItemsOnUse
     items:
     - id: ClothingOuterHardsuitEVAPrisoner
-
+# end of modifications
 
 #NTSRA Voidsuit / Ancient Voidsuit
 - type: entity
   parent: ClothingOuterEVASuitBase
   id: ClothingOuterHardsuitAncientEVA
   name: NTSRA voidsuit #Nanotrasen Space Research Association
-  description: An ancient space suit design, made by the Nanotrasen Space Research Association. They were so finely crafted way back when you can't tell how old this one is.
+  description: An ancient space suit design, made by the Nanotrasen Space Research Association. They were so finely crafted way back when you can't tell how old this one is. # Ronstation
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Suits/ancient_voidsuit.rsi
@@ -175,16 +178,16 @@
   parent: [ClothingOuterEVASuitBase, BaseMedicalContraband] #Despite "Voidsuits are light hardsuits", since it parents of EVA Suits, it goes with the other softsuits
   id: ClothingOuterHardsuitVoidParamed
   name: paramedic voidsuit
-  description: A lightweight voidfairing suit made for paramedics, providing the minimum protection you need to get in, get a body, and get out in a hazardous environment. Comes with a siren!
+  description: A lightweight voidfairing suit made for paramedics, providing the minimum protection you need to get in, get a body, and get out in a hazardous environment. Comes with a siren! # Ronstation
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/paramed.rsi
     layers:
     - state: icon
   - type: Appearance
-  - type: Item
-    shape:
-    -  0,0,1,4
+  - type: Item # Ronstation
+    shape: # Ronstation
+    -  0,0,1,4 # Ronstation
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/paramed.rsi
   - type: PressureProtection

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 - type: entity
   parent: ClothingOuterBaseLarge
   id: ClothingOuterSuitBomb
@@ -11,6 +13,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+  - type: Item # Ronstation
+    shape: # Ronstation
+    - 0,0,2,4 # Ronstation
   - type: Armor
     modifiers:
       coefficients:
@@ -50,10 +55,9 @@
     sprite: Clothing/OuterClothing/Suits/fire.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/fire.rsi
-  - type: Item
-    size: Large
-    shape:
-    - 0,0,1,4
+  - type: Item # Ronstation
+    shape: # Ronstation
+    - 0,0,1,4 # Ronstation
   - type: PressureProtection
     highPressureMultiplier: 0.04
   - type: TemperatureProtection
@@ -85,10 +89,9 @@
     sprite: Clothing/OuterClothing/Suits/atmos_firesuit.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/atmos_firesuit.rsi
-  - type: Item
-    size: Large
-    shape:
-    - 0,0,1,4
+  - type: Item # Ronstation
+    shape: # Ronstation
+    - 0,0,1,4 # Ronstation
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
@@ -128,6 +131,9 @@
       coefficients:
         Heat: 0.90
         Radiation: 0.01
+  - type: Item # Ronstation
+    shape: # Ronstation
+    - 0,0,1,3 # Ronstation
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/rad.rsi
   - type: GroupExamine

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 - type: entity
   parent: ClothingOuterStorageBase
   id: ClothingOuterWinterCoat
@@ -100,10 +102,10 @@
     clothingPrototype: ClothingHeadHatHoodWinterBartender
 
 - type: entity
-  parent: [AllowSuitStorageClothing, ClothingOuterWinterCoatToggleable, BaseCommandContraband]
+  parent: [AllowSuitStorageClothing, ClothingOuterWinterCoatToggleable, BaseCommandContraband] # Ronstation
   id: ClothingOuterWinterCap
-  name: captain's armored winter coat
-  description: A regal winter coat made of premium furs, concealing discrete armor plating. Not as robust against brute damage, but will keep you warm and has pockets to hold more unimportant things.
+  name: captain's armored winter coat # Ronstation
+  description: A regal winter coat made of premium furs, concealing discrete armor plating. Not as robust against brute damage, but will keep you warm and has pockets to hold more unimportant things. # Ronstation
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/WinterCoats/coat.rsi
@@ -115,8 +117,8 @@
       - state: CAP-inhand-left
       right:
       - state: CAP-inhand-right
-    shape:
-    - 0,0,1,2
+    shape: # Ronstation
+    - 0,0,1,2 # Ronstation
   - type: Clothing
     sprite: Clothing/OuterClothing/WinterCoats/coat.rsi
     clothingVisuals:
@@ -124,6 +126,7 @@
       - state: CAP-equipped-OUTERCLOTHING
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterCaptain
+# start of modifications
   - type: Armor
     modifiers:
       coefficients:
@@ -135,6 +138,7 @@
         Shock: 0.7
   - type: ExplosionResistance
     damageCoefficient: 0.9
+# end of modifications
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -681,10 +685,10 @@
     clothingPrototype: ClothingHeadHatHoodWinterSci
 
 - type: entity
-  parent: [AllowSuitStorageClothing, ClothingOuterWinterCoatToggleable, BaseSecurityContraband]
+  parent: [AllowSuitStorageClothing, ClothingOuterWinterCoatToggleable, BaseSecurityContraband] # Ronstation
   id: ClothingOuterWinterSec
-  name: security armored winter coat
-  description: While less armored than a standard armor vest, still keeps you protected. Also keeps you warm and has pockets!
+  name: security armored winter coat # Ronstation
+  description: While less armored than a standard armor vest, still keeps you protected. Also keeps you warm and has pockets! # Ronstation
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/WinterCoats/coat.rsi
@@ -696,8 +700,8 @@
       - state: SEC-inhand-left
       right:
       - state: SEC-inhand-right
-    shape:
-    - 0,0,1,2
+    shape: # Ronstation
+    - 0,0,1,2 # Ronstation
   - type: Clothing
     sprite: Clothing/OuterClothing/WinterCoats/coat.rsi
     clothingVisuals:
@@ -705,6 +709,7 @@
       - state: SEC-equipped-OUTERCLOTHING
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterSec
+# start of modifications
   - type: Armor
     modifiers:
       coefficients:
@@ -712,6 +717,7 @@
         Blunt: 0.75
         Piercing: 0.8
         Heat: 0.7
+# end of modifications
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/crates.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/crates.yml
@@ -248,26 +248,6 @@
     chance: 0.9
     offset: 0.0
 
-- type: entity
-  name: random air crate spawner
-  id: LootSpawnerRandomCrateAir
-  parent: MarkerBase
-  components:
-  - type: Sprite
-    layers:
-      - state: red
-      - sprite: Structures/Storage/Crates/o2.rsi
-        state: icon
-  - type: RandomSpawner
-    rarePrototypes:
-      - CrateEVASuitsBasic
-    rareChance: 0.2
-    prototypes:
-    - CrateEmergencyInternals
-    - CrateEmergencyInternalsLarge
-    - CrateNitrogenInternals
-    chance: 0.9
-
 - type: entityTable
   id: LockboxTable
   table: !type:GroupSelector

--- a/Resources/Prototypes/Recipes/Lathes/Packs/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/clothing.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 ## Static
 
 - type: latheRecipePack
@@ -146,7 +148,9 @@
   - ClothingOuterWinterCMO
   - ClothingOuterWinterHoP
   - ClothingOuterWinterHoSUnarmored
+  - ClothingOuterWinterHoS # Ronstation
   - ClothingOuterWinterWardenUnarmored
+  - ClothingOuterWinterWarden # Ronstation
   - ClothingOuterWinterQM
   - ClothingOuterWinterRD
   - ClothingOuterWinterMusician

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 # Base prototypes
 
 - type: latheRecipe
@@ -25,7 +27,7 @@
   id: BaseCoatRecipe
   categories:
   - Coats
-  completetime: 3.2 # don't ask why its faster than a jumpsuit??
+  completetime: 6 # Ronstation
   materials:
     Cloth: 500
     Durathread: 200
@@ -612,6 +614,12 @@
   parent: BaseCommandCoatRecipe
   id: ClothingOuterWinterCap
   result: ClothingOuterWinterCap
+# start of modifications
+  materials:
+    Cloth: 500
+    Durathread: 300
+    Steel: 300
+# end of modifications
 
 - type: latheRecipe
   parent: BaseCommandCoatRecipe
@@ -638,10 +646,32 @@
   id: ClothingOuterWinterHoSUnarmored
   result: ClothingOuterWinterHoSUnarmored
 
+# start of modifications
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingOuterWinterHoS
+  result: ClothingOuterWinterHoS
+  materials:
+    Cloth: 500
+    Durathread: 200
+    Steel: 200
+# end of modifications
+
 - type: latheRecipe
   parent: BaseCommandCoatRecipe
   id: ClothingOuterWinterWardenUnarmored
   result: ClothingOuterWinterWardenUnarmored
+
+# start of modifications
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingOuterWinterWarden
+  result: ClothingOuterWinterWarden
+  materials:
+    Cloth: 500
+    Durathread: 200
+    Steel: 200
+# end of modifications
 
 - type: latheRecipe
   parent: BaseCommandCoatRecipe
@@ -753,6 +783,10 @@
   parent: BaseCoatRecipe
   id: ClothingOuterWinterSec
   result: ClothingOuterWinterSec
+  materials:
+    Cloth: 300
+    Durathread: 200
+    Steel: 100
 
 - type: latheRecipe
   parent: BaseCoatRecipe

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -83,47 +83,7 @@
     Plastic: 1000
     Plasma: 500
     Glass: 500
-
-- type: latheRecipe
-  id: ClothingHeadHelmetRiot
-  result: ClothingHeadHelmetRiot
-  categories:
-  - Clothing
-  completetime: 4
-  materials:
-    Steel: 200
-    Plastic: 300
-
-- type: latheRecipe
-  id: ClothingOuterArmorRiot
-  result: ClothingOuterArmorRiot
-  categories:
-  - Clothing
-  completetime: 6
-  materials:
-    Steel: 500
-    Plastic: 350
-
-- type: latheRecipe
-  id: ClothingOuterArmorBulletproof
-  result: ClothingOuterArmorBulletproof
-  categories:
-  - Clothing
-  completetime: 6
-  materials:
-    Steel: 700
-    Plastic: 200
-
-- type: latheRecipe
-  id: ClothingOuterArmorReflective
-  result: ClothingOuterArmorReflective
-  categories:
-  - Clothing
-  materials:
-    Steel: 400
-    Plastic: 200
-    Glass: 400
-
+      
 # Shields
 - type: latheRecipe
   parent: BaseShieldRecipe

--- a/Resources/Prototypes/Ronstation/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -1,7 +1,7 @@
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseCentcommCommandContraband]
+  parent: [AllowSuitStorageClothing, ClothingOuterWinterCoatToggleable, BaseCentcommCommandContraband]
   id: ClothingOuterWinterBlueshield
-  name: blueshield winter coat
+  name: blueshield armored winter coat
   components:
   - type: Sprite
     sprite: Ronstation/Clothing/OuterClothing/WinterCoats/coat.rsi
@@ -18,5 +18,12 @@
     clothingVisuals:
       outerClothing:
       - state: BLUESHIELD-equipped-OUTERCLOTHING
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.75
+        Slash: 0.75
+        Piercing: 0.8
+        Heat: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterBlueshield

--- a/Resources/Prototypes/_Ronstation/Entities/Markers/Spawners/Random/crates.yml
+++ b/Resources/Prototypes/_Ronstation/Entities/Markers/Spawners/Random/crates.yml
@@ -1,0 +1,19 @@
+- type: entity
+  name: random air crate spawner
+  id: LootSpawnerRandomCrateAir
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Structures/Storage/Crates/o2.rsi
+        state: icon
+  - type: RandomSpawner
+    rarePrototypes:
+      - CrateEVASuitsBasic
+    rareChance: 0.2
+    prototypes:
+    - CrateEmergencyInternals
+    - CrateEmergencyInternalsLarge
+    - CrateNitrogenInternals
+    chance: 0.9

--- a/Resources/Prototypes/_Ronstation/Recipes/Crafting/meddiag_hud.yml
+++ b/Resources/Prototypes/_Ronstation/Recipes/Crafting/meddiag_hud.yml
@@ -1,0 +1,28 @@
+﻿- type: constructionGraph
+  id: HudMedDiag
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: meddiagHud
+          steps:
+            - tag: HudMedical
+              name: construction-graph-tag-medical-hud
+              icon:
+                sprite: Clothing/Eyes/Hud/med.rsi
+                state: icon
+              doAfter: 5
+            - tag: HudDiagnostic
+              name: construction-graph-tag-diagnostic-hud
+              icon:
+                sprite: Clothing/Eyes/Hud/diag.rsi
+                state: icon
+              doAfter: 5
+            - material: Cable
+              amount: 5
+              doAfter: 5
+            - material: Manipulator
+              amount: 2
+              doAfter: 5
+    - node: meddiagHud
+      entity: ClothingEyesHudMedDiag

--- a/Resources/Prototypes/_Ronstation/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_Ronstation/Recipes/Lathes/security.yml
@@ -1,0 +1,39 @@
+- type: latheRecipe
+  id: ClothingHeadHelmetRiot
+  result: ClothingHeadHelmetRiot
+  categories:
+  - Clothing
+  completetime: 4
+  materials:
+    Steel: 200
+    Plastic: 300
+
+- type: latheRecipe
+  id: ClothingOuterArmorRiot
+  result: ClothingOuterArmorRiot
+  categories:
+  - Clothing
+  completetime: 6
+  materials:
+    Steel: 500
+    Plastic: 350
+
+- type: latheRecipe
+  id: ClothingOuterArmorBulletproof
+  result: ClothingOuterArmorBulletproof
+  categories:
+  - Clothing
+  completetime: 6
+  materials:
+    Steel: 700
+    Plastic: 200
+
+- type: latheRecipe
+  id: ClothingOuterArmorReflective
+  result: ClothingOuterArmorReflective
+  categories:
+  - Clothing
+  materials:
+    Steel: 400
+    Plastic: 200
+    Glass: 400


### PR DESCRIPTION
## About the PR
Sequel to #252 working out licensing issues, extending on previous changes, and fixing minor mistakes.

Radiation suits & bomb suits have changed storage sizes.
All suit storage units now come with a unique name.
Also the medsec HUD recipe no longer uses the handheld radio which i commit by accident but I was planning on adding that in another PR anyway.

## Why / Balance
It fixes things.

## Technical details
Minor changes in yaml. Migration of unique prototypes to _Ronstation subdirectory.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
