### PR TITLE
(Bugfix) Add whistle to objectivegroups, remove now gone warden hat objective

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -1,3 +1,5 @@
+# # Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 # Traitor
 - type: weightedRandom
   id: TraitorObjectiveGroups

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -72,7 +72,10 @@
   weights:
     ForensicScannerStealObjective: 1                    #sec
     FlippoEngravedLighterStealObjective: 0.5
-    ClothingHeadHatWardenStealObjective: 1
+    # start of modifications
+    # ClothingHeadHatWardenStealObjective: 1
+    WardenWhistleStealObjective: 1
+    # end of modifications
     WantedListCartridgeStealObjective: 1
     ClothingOuterHardsuitVoidParamedStealObjective: 1   #med
     MedicalTechFabCircuitboardStealObjective: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed the warden hat objective from the objective's group and added the new warden's whistle objective. 

## Why / Balance
Bugfix for pr https://github.com/RonRonstation/ronstation/pull/274. Occasionally we could roll a non-existent objective and the server would not like that. We also *couldn't* roll the new objective, since it wasn't in the objectives group. We should be able to do that now.

## Technical details
changes to objectiveGroups.yml

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- fix: Warden Whistle objective had a bug preventing it from being rolled, and now should be able to be rolled.

