### PR TITLE
(Fix) Slimes now all use the parent's damage values

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -186,13 +186,15 @@
           Base: green_adult_slime
         Dead:
           Base: green_adult_slime_dead
-    - type: MeleeWeapon
-      damage:
-        types:
-          Blunt: 6
-          Structural: 4
-          Caustic: 1
-          Poison: 4
+    # start of modifications
+    # - type: MeleeWeapon
+    #   damage:
+    #     types:
+    #       Blunt: 6
+    #       Structural: 4
+    #       Caustic: 1
+    #       Poison: 4
+    # end of modifications
 
 - type: entity
   name: green slime
@@ -226,12 +228,14 @@
           Base: yellow_adult_slime
         Dead:
           Base: yellow_adult_slime_dead
-    - type: MeleeWeapon
-      damage:
-        types:
-          Blunt: 6
-          Structural: 4
-          Caustic: 4
+    # start of modifications
+    # - type: MeleeWeapon
+    #   damage:
+    #     types:
+    #       Blunt: 6
+    #       Structural: 4
+    #       Caustic: 4
+    # end of modifications
 
 - type: entity
   name: yellow slime


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Bugfix for https://github.com/RonRonstation/ronstation/pull/185

## Why / Balance
https://github.com/RonRonstation/ronstation/pull/185 attempted to nerf the slimes to make them less overwhelming for our population, but for some reason green and yellow slimes set the damage again in their own prototypes. This has been removed so that the slimes use their parent's (nerfed) damage values. 

## Technical details
changes to slime.yml commenting out some lines resetting the slime's damage for some slimes

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Yellow and green slimes no longer do more damage than their counterparts

