### PR TITLE
Raises minimum players required for the wizard spawn to 25

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -292,7 +292,7 @@
     duration: 1
     earliestStart: 30
     reoccurrenceDelay: 60
-    minimumPlayers: 10
+    minimumPlayers: 25 # Ronstation - modification. Wizard on lowpop is rough
   - type: AntagSelection
     agentName: wizard-round-end-name
     definitions:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Wizard now requires a minimum player count of 25 to spawn.

## Why / Balance
We've had a streak of low population games spectacularly ruined by vicious wizards lately. We've gotten lucky in the past that a lot of our players have tried to be interesting with the role on lower player counts, but given that upstream is already looking at doing this, and that currently wizard requires a measly 10(?!) players to spawn currently, it feels like a good idea to change this. If the mood changes, there's a rework upstream, or we manage to pull off a rework ourselves, then this shouldn't be a difficult number to tweak back down in the future.

## Technical details
events.yml parameter for the BaseWizardRule has changed

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Wizards require a player count of 25 to spawn now as opposed to the 10 it would before.

