### PR TITLE
Fix inline licensing comments appearing in some in-game text

### DIFF
--- a/Resources/Locale/en-US/_Ronstation/ghost/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Ronstation/ghost/ghost-role-component.ftl
@@ -1,0 +1,1 @@
+ghost-role-information-giant-spider-rules = You are a [color=yellow][bold]Free Agent[/bold][/color].

--- a/Resources/Locale/en-US/_Ronstation/research/technologies.ftl
+++ b/Resources/Locale/en-US/_Ronstation/research/technologies.ftl
@@ -1,0 +1,1 @@
+research-technology-portable-resuscitation = Portable Resuscitation

--- a/Resources/Locale/en-US/_Ronstation/station-events/events/bureaucratic-error.ftl
+++ b/Resources/Locale/en-US/_Ronstation/station-events/events/bureaucratic-error.ftl
@@ -1,0 +1,1 @@
+station-event-bureaucratic-error-announcement = A recent bureaucratic error in the Organic Resources Department may result in redundant staffing in some departments.

--- a/Resources/Locale/en-US/_Ronstation/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Ronstation/store/uplink-catalog.ftl
@@ -3,3 +3,5 @@ uplink-x4-desc = Blows up like most explosives. It can be attached to almost all
 
 uplink-x4-bundle-name = X-4 bundle
 uplink-x4-bundle-desc = Surprise. Contains 4 X-4 plastic explosives.
+
+uplink-grenade-launcher-bundle-desc = An old China-Lake grenade launcher bundled with 9 explosive rounds of varying yield.

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -47,7 +47,7 @@ ghost-role-information-snoth-description = A little snoth who doesn't mind a bit
 
 ghost-role-information-giant-spider-name = Giant Spider
 ghost-role-information-giant-spider-description = This station's inhabitants look mighty tasty, and your sticky web is perfect to catch them!
-ghost-role-information-giant-spider-rules = You are a [color={role-type-team-antagonist-color}][bold]{role-type-team-antagonist-name}[/bold][/color] with all other giant spiders. # Ronstation - modification. Spiders are free agents here
+# ghost-role-information-giant-spider-rules = You are a [color={role-type-team-antagonist-color}][bold]{role-type-team-antagonist-name}[/bold][/color] with all other giant spiders. # Ronstation - modification
 
 ghost-role-information-cognizine-description = Made conscious with the magic of cognizine.
 

--- a/Resources/Locale/en-US/research/technologies.ftl
+++ b/Resources/Locale/en-US/research/technologies.ftl
@@ -1,4 +1,3 @@
-# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
 research-discipline-none = None
 research-discipline-industrial = Industrial
 research-discipline-arsenal = Arsenal
@@ -67,7 +66,6 @@ research-technology-audio-visual-communication = A/V Communication
 research-technology-faux-astro-tiles = Faux Astro-Tiles
 research-technology-biochemical-stasis = Biochemical Stasis
 research-technology-mechanized-treatment = Mechanized Treatment
-research-technology-portable-resuscitation = Portable Resuscitation # Ronstation - modification
 research-technology-robotic-cleanliness = Robotic Cleanliness
 research-technology-advanced-cleaning = Advanced Cleaning
 research-technology-meat-manipulation = Meat Manipulation

--- a/Resources/Locale/en-US/station-events/events/bureaucratic-error.ftl
+++ b/Resources/Locale/en-US/station-events/events/bureaucratic-error.ftl
@@ -1,3 +1,3 @@
 ﻿# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
-station-event-bureaucratic-error-announcement = A recent bureaucratic error in the Organic Resources Department may result in redundant staffing in some departments. # Ronstation - modification
+# station-event-bureaucratic-error-announcement = A recent bureaucratic error in the Organic Resources Department may result in personnel shortages in some departments and redundant staffing in others. # Ronstation - Modification
 station-event-clerical-error-announcement = A minor clerical error in the Organic Resources Department has resulted in the permanent destruction of some of the station records.

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -256,7 +256,7 @@ uplink-buldog-bundle-name = Bulldog Bundle
 uplink-buldog-bundle-desc = Lean and mean: Contains the popular Bulldog Shotgun, a 12g slug drum, and four 12g buckshot drums.
 
 uplink-grenade-launcher-bundle-name = China-Lake Bundle
-uplink-grenade-launcher-bundle-desc = An old China-Lake grenade launcher bundled with 9 explosive rounds of varying yield. # Ronstation - modification
+# uplink-grenade-launcher-bundle-desc = An old China-Lake grenade launcher bundled with 11 rounds of varying destructive capability. # Ronstation - modification
 
 uplink-l6-saw-bundle-name = L6 Saw Bundle
 uplink-l6-saw-bundle-desc = More dakka: The iconic L6 light machine gun, bundled with 2 box magazines.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Moved all of the strings we've edited in upstream .ftl files into our own subdirectories. Restored the free agent status of the giant tarantulas.

## Why / Balance
Due to https://github.com/RonRonstation/ronstation/issues/296, we had to add a lot of comments to modified content in upstream files. In the course of doing this, I did not realize that you could not add inline comments to the strings in these .ftl files, causing these comments to show up in game erroneusly. To fix this, all modified strings have been moved into appropriate .ftil files and file paths under the _Ronstation subdirectory in en-US (which probably should have been the solution in the first place), and strings that were modified from upstream were restored and commented out. 

In the course of doing this, I realized that the change to ghot-role-component.ftl made in https://github.com/RonRonstation/ronstation/pull/190 was seemingly erroneously reverted at some point- probably a mistake in a merge conflict. As such, spiders incorrectly show as antagonists in the ghost role message when the mind-role given is still Free Agent. This has been fixed and now it will correctly tell you that spiders are free agents, able to cooperate or work against the crew at their leisure.

## Technical details
New .ftl files under _Ronstation, changes to strings in .ftl files. Changes to comments in some cases.

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- fix: Fixed inline comments erroneously showing in some strings in-game.
- fix: Giant Tarantula's rules text will now properly show you are a Free Agent and not a Team Antagonist.

