### PR TITLE
Restored borg recycling 

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -1,3 +1,5 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
+
 - type: entity
   parent: [BaseMob, StripableInventoryBase]
   id: BaseBorgChassisNotIonStormable
@@ -189,6 +191,14 @@
         !type:DamageTrigger
         damage: 300
       behaviors:
+      - !type:SpawnEntitiesBehavior # Ronstation. Start of modifications.
+        spawn:
+          SheetSteel1:
+            min: 10
+            max: 16
+          ShardGlass:
+            min: 1
+            max: 2  # Ronstation. End of modifications.
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak


### PR DESCRIPTION
## About the PR
Borgs now drop some of the materials used to create them.
> "I somehow deleted the local branch, the remote, and the pull request" - R.I.P previous branch
All commits were merged into one.

## Why / Balance
At the moment, borgs don't drop anything, even though you spend a stack of steel to make one.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: BrushTool
- tweak: Borgs now drop some of the materials used to create them.