### PR TITLE
Shorten system.dungeon logspam

### DIFF
--- a/Content.Server/Procedural/DungeonJob/DungeonJob.Ore.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.Ore.cs
@@ -1,3 +1,5 @@
+// Contains modifications made by Ronstation contributors, therefore this file is subject to MIT sublicensed with AGPL v3.0.
+using System.Linq; // Ronstation - modification.
 using System.Threading.Tasks;
 using Content.Shared.Procedural;
 using Content.Shared.Procedural.Components;
@@ -19,6 +21,8 @@ public sealed partial class DungeonJob
         HashSet<Vector2i> reservedTiles,
         Random random)
     {
+        var remaining = new Dictionary<EntProtoId, int>(); // Ronstation - modification.
+
         foreach (var dungeon in dungeons)
         {
             var emptyTiles = false;
@@ -141,11 +145,26 @@ public sealed partial class DungeonJob
                     }
                 }
 
+                // Start of modifications.
                 if (groupSize > 0)
                 {
-                    _sawmill.Warning($"Found remaining group size for ore veins of {gen.Replacement ?? "null"}!");
+                    var key = gen.Replacement ?? "null";
+                    if (remaining.ContainsKey(key))
+                    {
+                        remaining[key]++;
+                    }
+                    else
+                    {
+                        remaining.Add(key, 1);
+                    }
                 }
+                // End of modifications.
             }
         }
+
+        // Start of modifications.
+        if (remaining.Count > 0)
+            _sawmill.Warning($"Found remaining group size for groups, ore veins of {String.Join(", ", remaining.Select(kvp => $"{kvp.Key}: {kvp.Value}"))}!");
+        // End of modifications.
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Drastically reduced the amount of `system.dungeon` log spam
Instead of ~5-10k lines of log spam, it now prints the line, the ore vein in question, and the amount of times it had the issue

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Was bloating console logs

## Technical details
<!-- Summary of code changes for easier review. -->
Made the log count the amount of groups with remaining group size and print at the end of the function, instead of printing every single time there was a remaining group size.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="985" height="293" alt="image" src="https://github.com/user-attachments/assets/cbfbd76f-38e4-45de-bfe4-375a73a5d4d3" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Reduced system.dungeon log spam
