### PR TITLE
Add bulk trades for cubes

### DIFF
--- a/Resources/Prototypes/_Ronstation/Catalog/Cargo/cargo_livestock.yml
+++ b/Resources/Prototypes/_Ronstation/Catalog/Cargo/cargo_livestock.yml
@@ -1,0 +1,19 @@
+- type: cargoProduct
+  id: BulkLivestockMonkeyCube
+  icon:
+    sprite: Objects/Misc/monkeycube.rsi
+    state: box
+  product: BulkCrateNPCMonkeyCube
+  cost: 18000
+  category: cargoproduct-category-name-livestock
+  group: market
+
+- type: cargoProduct
+  id: BulkLivestockKoboldCube
+  icon:
+    sprite: Objects/Misc/monkeycube.rsi
+    state: box_kobold
+  product: BulkCrateNPCKoboldCube
+  cost: 18000
+  category: cargoproduct-category-name-livestock
+  group: market

--- a/Resources/Prototypes/_Ronstation/Catalog/Fills/Crates/npc.yml
+++ b/Resources/Prototypes/_Ronstation/Catalog/Fills/Crates/npc.yml
@@ -1,0 +1,21 @@
+- type: entity
+  id: BulkCrateNPCMonkeyCube
+  parent: CrateGenericSteel
+  name: bulk monkey cube crate
+  description: 10 boxes of monkey cubes for the price of 9!
+  components:
+  - type: StorageFill
+    contents:
+      - id: MonkeyCubeBox
+        amount: 10
+
+- type: entity
+  id: BulkCrateNPCKoboldCube
+  parent: CrateGenericSteel
+  name: bulk kobold cube crate
+  description: 10 boxes of kobold cubes for the price of 9!
+  components:
+  - type: StorageFill
+    contents:
+      - id: KoboldCubeBox
+        amount: 10


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added bulk monkey cube and bulk kobold cube crates, available for purchase from the ATS. 10 boxes of cubes for the price of 9!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Honestly just for Evac/EoR fun, making monkey/kobold "bombing" the shuttle just a tiny bit easier. Sometimes there is so much money left that the ATS runs out of space for all the cube crates you can buy, and repacking crates into one is a bit of a hassle.

The cubes are still wrapped and in their boxes, so this doesn't make the carpal tunnel inducing process of unpacking and unwrapping all of them any easier, just reduces the amount of leftover crates and offers a 10% discount

## Technical details
<!-- Summary of code changes for easier review. -->
Added BulkCrateNPCMonkeyCube and BulkCrateNPCKoboldCube, which are copies of CrateNPCMonkeyCube and CrateNPCKoboldCube but with 10 times the boxes
Also added cargo products BulkLivestockMonkeyCube and BulkLivestockKoboldCube, which are copies of LivestockKoboldCube and LivestockMonkeyCube, but refer to the previously mentioned bulk crates instead offered at 18000 each
 
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="576" height="104" alt="Screenshot 2025-07-29 134123" src="https://github.com/user-attachments/assets/6921b762-ed31-4212-a74d-7a0ff65db361" />
<img width="499" height="339" alt="Screenshot 2025-07-29 134105" src="https://github.com/user-attachments/assets/af63d278-5470-4490-b487-d72dde1f36d6" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Added bulk monkey cube and bulk kobold cube crates, available for purchase from the ATS.
