### PR TITLE
Revert advanced chemical rework.

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -143,9 +143,10 @@
   metabolisms:
     Medicine:
       effects:
-      - !type:EvenHealthChange
+      - !type:HealthChange
         damage:
-          Brute: -1.5
+          groups:
+            Brute: -2
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -825,7 +826,6 @@
   color: "#520e30"
   metabolisms:
     Medicine:
-      metabolismRate: 0.25
       effects:
       - !type:HealthChange
         conditions:
@@ -834,15 +834,15 @@
           max: 30
         damage:
           groups:
-            Toxin: -1.5
-            Brute: 0.25
+            Toxin: -3
+            Brute: 0.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 30
         damage:
           groups:
-            Toxin: -0.5
+            Toxin: -1
             Brute: 3
       - !type:AdjustReagent
         conditions:
@@ -952,19 +952,18 @@
   color: "#e0a5b9"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
       effects:
       - !type:HealthChange
         damage:
           types:
-            Caustic: -0.6 # 6 per u
+            Caustic: -3
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 21
+          min: 16
         damage:
           types:
-            Heat: 0.2
+            Heat: 2
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
@@ -1008,19 +1007,18 @@
   color: "#283332"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
       effects:
       - !type:HealthChange
         damage:
           types:
-            Slash: -0.6 # 6 Per u
+            Slash: -3
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 21
+          min: 12
         damage:
           types:
-            Cold: 1.5 #15 per u
+            Cold: 3
 
 - type: reagent
   id: Puncturase
@@ -1032,20 +1030,19 @@
   color: "#b9bf93"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
       effects:
       - !type:HealthChange
         damage:
           types:
-            Piercing: -0.6 # 6 per u
-            Blunt: 0.05 # 0.5 per u
+            Piercing: -4
+            Blunt: 0.1
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 21
+          min: 11
         damage:
           types:
-            Blunt: 1 # 10 per u plus base effect
+            Blunt: 5
 
 - type: reagent
   id: Bruizine
@@ -1057,19 +1054,18 @@
   color: "#ff3636"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
       effects:
       - !type:HealthChange
         damage:
           types:
-            Blunt: -0.6 # 6 per u
+            Blunt: -3.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 19
+          min: 10.5
         damage:
           types:
-            Poison: 1.5 # 15 per u
+            Poison: 4
 
 - type: reagent
   id: Holywater
@@ -1164,13 +1160,12 @@
   color: "#8147ff"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
       effects:
       # heals shocks and removes shock chems
       - !type:HealthChange
         damage:
           types:
-            Shock: -0.5 # 5 per u
+            Shock: -4
       - !type:AdjustReagent
         reagent: Licoxide
         amount: -4
@@ -1184,14 +1179,14 @@
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 15.5
+          min: 12
         damage:
           types:
-            Cold: 0.2 # 2 per u but lethal with cooling OD effect below
+            Cold: 2
       - !type:AdjustTemperature
         conditions:
         - !type:ReagentThreshold
-          min: 15.5
+          min: 12
         amount: -30000
       - !type:Jitter
         conditions:

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -436,6 +436,39 @@
     Bruizine: 2
 
 - type: reaction
+  id: BicarLacerinol # mixing any two brute medications will make Razorium
+  impact: Medium
+  reactants:
+    Lacerinol:
+      amount: 1
+    Bicaridine:
+      amount: 1
+  products:
+    Razorium: 1
+
+- type: reaction
+  id: BicarPuncturase # mixing any two brute medications will make Razorium
+  impact: Medium
+  reactants:
+    Puncturase:
+      amount: 1
+    Bicaridine:
+      amount: 1
+  products:
+    Razorium: 1
+
+- type: reaction
+  id: BicarBruizine # mixing any two brute medications will make Razorium
+  impact: Medium
+  reactants:
+    Bruizine:
+      amount: 1
+    Bicaridine:
+      amount: 1
+  products:
+    Razorium: 1
+
+- type: reaction
   id: BruizineLacerinol # mixing any two brute medications will make Razorium
   impact: Medium
   reactants:


### PR DESCRIPTION
I am not a fan of reverting upstream PRs "just like that", I consider it crass and often unnecessary, but I'm begrudgingly making this PR because this is something I personally have a strong opinion on as a medical main. C'est la vie.

## About the PR
Reverts merge PR of https://github.com/space-wizards/space-station-14/pull/38811 from upstream.

## Why / Balance
Community consensus upstream has shown this to be a poor change, I trust in upstream's maintainer team and personally would be fine for just waiting for a revert, but it's evident that these changes shouldn't stay, and I'm not going to keep our players who asked for it waiting (since i promised to revert it in a delirious sleep deprived state, lol)

The changes from the upstream PR are especially unfit for Ronstation, disregarding the Whole Swathe Of Other Issues.

## Technical details
git pull
git revert 0606ed5
git push

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
pretty sure this didn't even make it into our stable. lol. lmao.