### PR TITLE
Vent Critters post-factum changes

### DIFF
--- a/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -34,18 +34,30 @@ public sealed partial class VentCrittersRuleComponent : Component
     /// <summary>
     /// DeltaV: Base minimum number of critters to spawn.
     /// </summary>
-    [DataField]
-    public int Min = 2;
+    [DataField("min")]
+    public int Min = 3; // Ronstation - Changed from 2 to 3
 
     /// <summary>
     /// DeltaV: Base maximum number of critters to spawn.
     /// </summary>
-    [DataField]
-    public int Max = 3;
+    [DataField("max")]
+    public int Max = 4; // Ronstation - Changed from 3 to 4
 
     /// <summary>
     /// DeltaV: Min and max get multiplied by the player count then divided by this.
     /// </summary>
-    [DataField]
-    public int PlayerRatio = 25;
+    [DataField("playerRatio")]
+    public int PlayerRatio = 20; // Ronstation - Lowered PR from 25 to 20 to scale higher
+
+    /// <summary>
+    /// Ronstation: Cap for how many critters can be spawned, used in the calculation for count.
+    /// </summary>
+    [DataField("ceiling")]
+    public int Ceiling = 8;
+
+    /// <summary>
+    /// Ronstation: Floor for how many critters can be spawned, used in the calculation for count.
+    /// </summary>
+    [DataField("floor")]
+    public int Floor = 3;
 }

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -64,7 +64,7 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
         var players = _antag.GetTotalPlayerCount(_player.Sessions);
         var min = comp.Min * players / comp.PlayerRatio;
         var max = comp.Max * players / comp.PlayerRatio;
-        var count = Math.Max(RobustRandom.Next(min, max), 1);
+        var count = Math.Min(Math.Max(RobustRandom.Next(min, max), comp.Floor), comp.Ceiling); // Ronstation - Added a Math.Min to cap how many critters can spawn
         Log.Info($"Spawning {count} critters for {ToPrettyString(uid):rule}");
         for (int i = 0; i < count; i++)
         {

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2624,7 +2624,7 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        180: Dead
+        80: Dead # Ronstation - Clownspiders should be WEAKER than Tarantulas, not stronger
     - type: Spider
       webPrototype: SpiderWebClown
     - type: MeleeWeapon

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -471,24 +471,25 @@
     table: # DeltaV: EntityTable instead of spawn entries
       id: MobGiantSpiderAngry
 
-# start of modifications
-#- type: entity
-#  id: SpiderClownSpawn
-#  parent: BaseStationEventShortDelay
-#  components:
-#  - type: StationEvent
-#    startAnnouncement: station-event-vent-creatures-start-announcement
-#    startAudio:
-#      path: /Audio/Announcements/attention.ogg
-#    earliestStart: 20
-#    minimumPlayers: 20
-#    weight: 1.5
-#    duration: 60
-#  - type: VentCrittersRule
-#    entries:
-#    - id: MobClownSpider
-#      prob: 0.05
-# end of modifications
+- type: entity
+  id: SpiderClownSpawn
+  parent: BaseStationEventShortDelay
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-vent-creatures-start-announcement
+    startAudio:
+      path: /Audio/Announcements/attention.ogg
+    earliestStart: 20
+    minimumPlayers: 20
+    weight: 1.5
+    duration: 60
+  - type: VentCrittersRule
+    table: # DeltaV: EntityTable instead of spawn entries
+      id: MobClownSpider
+    min: 1 # Ronstation - Clownspiders are annoying and so not as many spawn when they are rolled
+    max: 2
+    ceiling: 4
+    floor: 1
 
 - type: entity
   id: ZombieOutbreak

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -23,7 +23,7 @@
     - id: SlimesSpawn
     - id: SolarFlare
     - id: SnakeSpawn
-#    - id: SpiderClownSpawn - Ronstation - modification. No.
+    - id: SpiderClownSpawn
     - id: SpiderSpawn
     - id: VentClog
 

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -35,6 +35,9 @@
       - id: MobMouse
       - id: MobMouse1
       - id: MobMouse2
+    ceil: 10
+    playerRatio: 17
+    floor: 1
       #- id: MobMouseCancer DeltaV - No
 # Events always spawn a critter regardless of Probability https://github.com/space-wizards/space-station-14/issues/28480 I added the Rat King to their own event with a player cap.
 
@@ -57,6 +60,9 @@
       - id: MobMouse1
       - id: MobMouse2
       - id: MobMouseCancer
+    ceil: 10 # Ronstation - Pests have a higher ceiling and lower PR to spawn more critters
+    playerRatio: 17
+    floor: 1 # Ronstation - Mice can be annoying so we add some variance into how many they can spawn at lower pops
     specialEntries:
     - id: SpawnPointGhostRatKing
       prob: 0.001
@@ -82,6 +88,8 @@
         weight: 0.008
       - id: MobMoproach
         weight: 0.004
+    ceil: 10 # Ronstation - Pests have a higher ceiling and lower PR to spawn more critters
+    playerRatio: 17
 
 - type: entity
   id: SnailMigrationLowPop
@@ -99,6 +107,8 @@
       - id: MobSnail
       - id: MobSnailSpeed
       - id: MobSnailMoth
+    ceil: 10 # Ronstation - Pests have a higher ceiling and lower PR to spawn more critters
+    playerRatio: 17
 
 - type: entity
   id: SnailMigration
@@ -122,3 +132,5 @@
       - id: MobSnailMoth
         weight: 0.08
       # - id: MobSnailInstantDeath DeltaV - No
+    ceil: 10 # Ronstation - Pests have a higher ceiling and lower PR to spawn more critters
+    playerRatio: 17

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -35,9 +35,9 @@
       - id: MobMouse
       - id: MobMouse1
       - id: MobMouse2
-    ceil: 10
+    ceil: 10 # Ronstation - Pests have a higher ceiling and lower PR to spawn more critters
     playerRatio: 17
-    floor: 1
+    floor: 1 # Ronstation - Mice can be annoying so we add some variance into how many they can spawn at lower pops
       #- id: MobMouseCancer DeltaV - No
 # Events always spawn a critter regardless of Probability https://github.com/space-wizards/space-station-14/issues/28480 I added the Rat King to their own event with a player cap.
 

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -35,7 +35,7 @@
       - id: MobMouse
       - id: MobMouse1
       - id: MobMouse2
-    ceil: 10 # Ronstation - Pests have a higher ceiling and lower PR to spawn more critters
+    ceiling: 10 # Ronstation - Pests have a higher ceiling and lower PR to spawn more critters
     playerRatio: 17
     floor: 1 # Ronstation - Mice can be annoying so we add some variance into how many they can spawn at lower pops
       #- id: MobMouseCancer DeltaV - No
@@ -60,7 +60,7 @@
       - id: MobMouse1
       - id: MobMouse2
       - id: MobMouseCancer
-    ceil: 10 # Ronstation - Pests have a higher ceiling and lower PR to spawn more critters
+    ceiling: 10 # Ronstation - Pests have a higher ceiling and lower PR to spawn more critters
     playerRatio: 17
     floor: 1 # Ronstation - Mice can be annoying so we add some variance into how many they can spawn at lower pops
     specialEntries:
@@ -88,7 +88,7 @@
         weight: 0.008
       - id: MobMoproach
         weight: 0.004
-    ceil: 10 # Ronstation - Pests have a higher ceiling and lower PR to spawn more critters
+    ceiling: 10 # Ronstation - Pests have a higher ceiling and lower PR to spawn more critters
     playerRatio: 17
 
 - type: entity
@@ -107,7 +107,7 @@
       - id: MobSnail
       - id: MobSnailSpeed
       - id: MobSnailMoth
-    ceil: 10 # Ronstation - Pests have a higher ceiling and lower PR to spawn more critters
+    ceiling: 10 # Ronstation - Pests have a higher ceiling and lower PR to spawn more critters
     playerRatio: 17
 
 - type: entity
@@ -132,5 +132,5 @@
       - id: MobSnailMoth
         weight: 0.08
       # - id: MobSnailInstantDeath DeltaV - No
-    ceil: 10 # Ronstation - Pests have a higher ceiling and lower PR to spawn more critters
+    ceiling: 10 # Ronstation - Pests have a higher ceiling and lower PR to spawn more critters
     playerRatio: 17


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Un-hardcoded several vars in the VentCrittersRuleComponent, allowing us to set the scaling and amount of critters on an individual basis.
- Added a var for the number being used as the floor for calculating how many creatures to spawn. Set that floor to 3 by default, as opposed to the 1 it was before
- Modified the calculation determining how many critters spawn to include a ceiling for how many critters can spawn, and added an accompanying var in the VentCrittersRuleComponent
- Changed the base scaling, min, and max of the calculation to increase the number of spawns.
- Modified the prototypes of the pest spawning events to allow for higher numbers of them to spawn.
- Re-added the dreaded clown-spider spawn event. Modified vars to make them less numerous when they spawn compared to other hostile critters
- Also severely nerfed their health pools from 180 to 80. Given their other advantages, they don't really need to be twice(!) as healthy as tarantulas

## Why / Balance
Consensus seems to be that not enough creatures spawn during VentCritter events to be a real threat, especially since the event gives a clear warning as to the location of the spawn. These changes hope to increase the potential threat from the event without being overbearing. Many of the variables used to calculate how many creatures the event should spawn are no longer hard-coded, allowing us more control over the event. Given this, and the fact that slipping is no longer as much of a death sentence anymore, clown spiders have been re-enabled to add a bit more variety to the event. Given the relative strength of the clown spider compared to other mobs, their health was significantly decreased, and for now, the number of clown spiders that will spawn is significantly lower than other critter events. Hopefully this should make them much less frustrating opponents. 

## Technical details
Minor changes to C#, including the calculation for the count var in VentCrittersRule, and allowing many vars used by the accompanying component to be set by individual prototypes. Some changes to the yaml in pests.yml and events.yml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: The dreaded clown-spider returns, with a significantly decreased health pool (80 to dead instead of 180 to dead). Fewer should spawn on average compared to the hostile creatures in other vent critter events.
- tweak: Vent critter events should spawn more creatures overall.
