### PR TITLE
Make SyndiMothroaches not useless

### DIFF
--- a/Resources/Locale/en-US/ronstation/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ronstation/ghost/roles/ghost-role-component.ftl
@@ -8,5 +8,6 @@ ghost-role-information-centcom-blueshield-officer-name = Blueshield Officer
 ghost-role-information-centcom-blueshield-officer-description = Become bodyguard for visiting officers or other VIP. Blueshield officers employed by Central Command enjoy higher access than on the station.
 
 ghost-role-information-SyndiMothroach-name = SyndiMothroach
-ghost-role-information-SyndiMothroach-description = You're the faithful trained pet of nuclear operatives with a bit of biting power to scare the enemies. Serve your master to the death!
-ghost-role-information-SyndiMothroach-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with the agent who summoned you.
+ghost-role-information-SyndiMothroach-description = You're a highly engineered pest, pet of syndicate agents. Serve your master to the death and bite through whatever or whoever you have to.
+ghost-role-information-SyndiMothroach-rules = You are a [color=red][bold]Team Antagonist[/bold][/color
+] with the agent who summoned you.

--- a/Resources/Locale/en-US/ronstation/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ronstation/ghost/roles/ghost-role-component.ftl
@@ -9,5 +9,4 @@ ghost-role-information-centcom-blueshield-officer-description = Become bodyguard
 
 ghost-role-information-SyndiMothroach-name = SyndiMothroach
 ghost-role-information-SyndiMothroach-description = You're a highly engineered pest, pet of syndicate agents. Serve your master to the death and bite through whatever or whoever you have to.
-ghost-role-information-SyndiMothroach-rules = You are a [color=red][bold]Team Antagonist[/bold][/color
-] with the agent who summoned you.
+ghost-role-information-SyndiMothroach-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with the agent who summoned you.

--- a/Resources/Locale/en-US/ronstation/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/ronstation/store/uplink-catalog.ftl
@@ -1,2 +1,2 @@
 uplink-mobmothroach-syndicate-name = SyndiMothroach Teleporter
-uplink-mobmothroach-syndicate-desc = Call in a handy mothroach to harass your foes. Can bite painfully.
+uplink-mobmothroach-syndicate-desc = Call in a handy mothroach to harass your foes and chew through wires.

--- a/Resources/Prototypes/Ronstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Ronstation/Catalog/uplink_catalog.yml
@@ -6,8 +6,8 @@
   productEntity: ReinforcementRadioSyndicateSyndiMothroach
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 2
   cost:
-    Telecrystal: 5
+    Telecrystal: 3
   categories:
     - UplinkAllies

--- a/Resources/Prototypes/Ronstation/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Ronstation/Entities/Mobs/NPCs/animals.yml
@@ -76,12 +76,11 @@
   - type: Bloodstream
     bloodReagent: InsectBlood
   - type: Respirator
-    damage:
-      types:
-        Asphyxiation: 0.5
-    damageRecovery:
-      types:
-        Asphyxiation: -0.5
+    minSaturation: 5.0
+  - type: PressureImmunity
+  - type: Temperature
+    heatDamageThreshold: 423
+    coldDamageThreshold: 0
   - type: CombatMode
   - type: Butcherable
     spawned:
@@ -100,12 +99,13 @@
       Unsexed: UnisexMoth
     wilhelmProbability: 0.001
   - type: MobPrice
-    price: 200
+    price: 700
   - type: Tag
     tags:
     - Trash
     - CannotSuicide
     - VimPilot
+    - Unimplantable # better than syndicat when microbomb
   - type: CanEscapeInventory
   - type: NpcFactionMember
     factions:
@@ -130,8 +130,9 @@
     damage:
       types:
         Slash: 4
-        Piercing: 4
-        Structural: 6
+        Piercing: 6
+        Structural: 15
+  - type: Insulated
   - type: FireVisuals
     sprite: Mobs/Effects/onfire.rsi
     normalState: Mouse_burning


### PR DESCRIPTION
## About the PR
Makes syndimothroaches spaceproof.
Buffs their attack power (4 slash + 6 piercing, 15 structural)
Makes them insulated (shockproof)
Lowers their price in the uplink (3 base cost, 2 on discount, from 5 base 4 discount)
Makes them unimplantable (syndimoth + minibomb is just a better syndicat, that should not be possible)

Syndimothroaches now have an actual use beyond admin spawns and cute bait. They still die in 5 swings of a crowbar.

## Why / Balance
Currently, syndimothroaches are _entirely_ useless. They deal a whopping eight (8) damage to people and do absolutely nothing else, for the low low price of a quarter of a traitor uplink. And (and) they die near instantly in space, ergo they are entirely useless to nuclear operatives.
This PR makes them able to at the very least chew through wires without dying, mess up structures very ineffectively, and survive in space.

## Technical details
Changes in yml and cleanup in ftl.

## Media
https://github.com/user-attachments/assets/41a57627-c534-4a77-9a48-bf068b7aaa83

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: arenaconspiracy
- tweak: Syndimothroaches are now spaceproof.
- tweak: Syndimothroaches are now insulated.
- tweak: Syndimothroaches bite ever so slightly stronger.
- tweak: Syndimothroaches are now 2 telecrystals cheaper.