### PR TITLE
Add Atlas 3 & Feint Station to rotation

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -1,3 +1,4 @@
+# Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
 - type: gameMapPool
   id: DefaultMapPool
   maps:
@@ -10,8 +11,10 @@
   - Oasis
   - Packed
   - Plasma
-  #- Reach
   - Exo
-  - Saltern2
+# start of modifications
+  - Atlas3
   - Cluster2
-  #- Atlas2 # Ronstation - Derotated for the time being until enough rework is made.
+  - Feint
+  - Saltern2
+# end of modifications


### PR DESCRIPTION
## About the PR
Adds NT-ACS Atlas 3 Installation & NT-TE Feint Station to the default maps pool. Making them available for vote between their designated player thresholds.

## Why / Balance
After the latest set of patches for both maps, I consider them stable enough for live rotation, as their architect. We still have the forum threads for any new issues that crop up, and I will continue making patches to them as long as me and the maps are here.

## Technical details
One (1) yml file edited.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: arenaconspiracy
- add: The map Atlas 3 is now available for vote between 0 and 35 players.
- add: The map Feint Station is now available for vote between 15 and 35 players.