### PR TITLE
Make new life rule enforced under LRP

### DIFF
--- a/Resources/Prototypes/Guidebook/rules.yml
+++ b/Resources/Prototypes/Guidebook/rules.yml
@@ -195,7 +195,7 @@
   id: RuleR4
   name: guide-entry-rules-r4
   ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml"
+  text: "/ServerInfo/_Ronstation/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml" # Ronstation - modification
 
 - type: guideEntry
   id: RuleR5

--- a/Resources/ServerInfo/_Ronstation/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
+++ b/Resources/ServerInfo/_Ronstation/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
@@ -8,14 +8,14 @@ Unless otherwise specified, when playing as a different character (such as takin
 The knowledge that a round will end is out of character information. Knowledge that the shift will end however, is not out of character information. The intention of this rule is to prevent preparation for End of round griefing (EORG). Utilising the knowledge that the round will end is metagaming.
 
 ### Knowledge from past lives
-Except when otherwise specified, you cannot use any information gained in a past life in the same round.
+Except when otherwise specified, you cannot use any information gained in a past life (i.e., different character) in the same round.
 For example, if you were killed by an antagonist, you cannot warn the crew of said antagonist when you respawn as a mothroach.
-This does _not_ apply when being brought back from death as the same character, having your brain transferred to another body, or being cloned.
-For example, if you were killed by an antagonist, your body was found and your brain was placed in a borg, you can recall what happened prior to your original death and could warn the of the antagonist.
+In the cases of being cloned post-mortem, or having your brain be put into a cyborg via a MMI, these characters _MAY_ retain memories of events prior to the death of their original body, but must follow new life rules regarding death (see 'Knowledge gained while crit, knowledge lost in death').
+For example, if you were killed by an antagonist, your body was found and your brain was placed in a borg, you can recall what happened prior to your original death, but you may not recall details of what lead to your death.
 
 ### Knowledge that the round will end (and your character will, ergo, cease to exist)
 Your character will, or should, know that their current shift on Space Station 14 will end and that they will return to Centcomm. They do not know that this represents the effective end of their existence from the perspective of their player.
-You cannot preprepare for end-of-round griefing (EORG) or perform other actions that only make sense in the context that, your characters life ultimately doesn't matter.
+You cannot prepare for end-of-round griefing (EORG) or perform other actions that only make sense in the context that, your characters life ultimately doesn't matter.
 
 ### Knowledge gained via LOOC
 You cannot use any knowledge gained via LOOC chat that is not in the context of assisting a player with controls, game mechanics, or being made to feel welcome. No in character information should be shared via LOOC, and no actions should be taken or altered because of LOOC or OOC chats.

--- a/Resources/ServerInfo/_Ronstation/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
+++ b/Resources/ServerInfo/_Ronstation/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
@@ -10,8 +10,8 @@ The knowledge that a round will end is out of character information. Knowledge t
 ### Knowledge from past lives
 Except when otherwise specified, you cannot use any information gained in a past life (i.e., different character) in the same round.
 For example, if you were killed by an antagonist, you cannot warn the crew of said antagonist when you respawn as a mothroach.
-In the cases of being cloned post-mortem, or having your brain be put into a cyborg via a MMI, these characters _MAY_ retain memories of events prior to the death of their original body, but must follow new life rules regarding death (see 'Knowledge gained while crit, knowledge lost in death').
-For example, if you were killed by an antagonist, your body was found and your brain was placed in a borg, you can recall what happened prior to your original death, but you may not recall details of what lead to your death.
+In the cases of being cloned post-mortem, having your brain be put into a cyborg via a MMI, or splitting into nymphs as a diona, these characters are allowed to retain memories of events prior to the death of their original body, but must follow new life rules regarding death (see 'Knowledge gained while crit, knowledge lost upon death').
+For example, if you were killed by an antagonist, your body was found and your brain was placed in a borg, you can recall what happened prior to your original death, except for details of what lead to your death.
 
 ### Knowledge that the round will end (and your character will, ergo, cease to exist)
 Your character will, or should, know that their current shift on Space Station 14 will end and that they will return to Centcomm. They do not know that this represents the effective end of their existence from the perspective of their player.
@@ -20,7 +20,7 @@ You cannot prepare for end-of-round griefing (EORG) or perform other actions tha
 ### Knowledge gained via LOOC
 You cannot use any knowledge gained via LOOC chat that is not in the context of assisting a player with controls, game mechanics, or being made to feel welcome. No in character information should be shared via LOOC, and no actions should be taken or altered because of LOOC or OOC chats.
 
-### Knowledge gained while in crit, knowledge lost in death
+### Knowledge gained while in crit, knowledge lost upon death
 Being in the critically injured state or otherwise unconscious (includes sleeping) prevents your character from remembering anything that happened to or around them while unconscious. If brought out of the critical state to the alive state, you may remember what caused you to enter critical state. Entering the dead state causes your character to forget all events related to their death (if you can tie it to how you died, do not remember it). If revived, placed in a MMI, or in the case of Diona, splitting, the character is aware of the fact that they have died but not how.
 
 ## Do Not Metafriend or Metagrudge

--- a/Resources/ServerInfo/_Ronstation/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
+++ b/Resources/ServerInfo/_Ronstation/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
@@ -1,0 +1,56 @@
+<Document>
+  # Roleplay Rule 4 -# Do not use information your character would not have knowledge of.
+Metagaming in Space station 14 is the term used to typically describe actions based on knowledge during a round that is inaccessible to your character. You cannot use information gained while dead or a ghost if you are alive. Use of information gained while dead is considered metagaming. This does not apply to knowledge of what antagonists are capable of doing. We expect players to understand what options are avaliable to antagonists.
+
+## Out of character information and metagaming.
+Unless otherwise specified, when playing as a different character (such as taking a ghost role or being changed to another character via admin intervention), you are to act without knowledge of what occurred in the round as any prior characters and as a ghost while playing a character (ghosts are not considered a character for this rule). Mindswap spells and polymorphs are not considered changing characters for this rule. Failure to follow this is metagaming.
+
+The knowledge that a round will end is out of character information. Knowledge that the shift will end however, is not out of character information. The intention of this rule is to prevent preparation for End of round griefing (EORG). Utilising the knowledge that the round will end is metagaming.
+
+### Knowledge from past lives
+Except when otherwise specified, you cannot use any information gained in a past life in the same round.
+For example, if you were killed by an antagonist, you cannot warn the crew of said antagonist when you respawn as a mothroach.
+This does _not_ apply when being brought back from death as the same character, having your brain transferred to another body, or being cloned.
+For example, if you were killed by an antagonist, your body was found and your brain was placed in a borg, you can recall what happened prior to your original death and could warn the of the antagonist.
+
+### Knowledge that the round will end (and your character will, ergo, cease to exist)
+Your character will, or should, know that their current shift on Space Station 14 will end and that they will return to Centcomm. They do not know that this represents the effective end of their existence from the perspective of their player.
+You cannot preprepare for end-of-round griefing (EORG) or perform other actions that only make sense in the context that, your characters life ultimately doesn't matter.
+
+### Knowledge gained via LOOC
+You cannot use any knowledge gained via LOOC chat that is not in the context of assisting a player with controls, game mechanics, or being made to feel welcome. No in character information should be shared via LOOC, and no actions should be taken or altered because of LOOC or OOC chats.
+
+### Knowledge gained while in crit, knowledge lost in death
+Being in the critically injured state or otherwise unconscious (includes sleeping) prevents your character from remembering anything that happened to or around them while unconscious. If brought out of the critical state to the alive state, you may remember what caused you to enter critical state. Entering the dead state causes your character to forget all events related to their death (if you can tie it to how you died, do not remember it). If revived, placed in a MMI, or in the case of Diona, splitting, the character is aware of the fact that they have died but not how.
+
+## Do Not Metafriend or Metagrudge
+Giving a person or character preferential treatment based on the events of a previous round is considered metafriending. Treating a person or character negatively based on the events of a previous round is considered metagrudging.
+
+#### Metafriending Examples
+These are all examples of things that are prohibited.
+- Giving a character additional access or a job because you are friends with the player who is playing that character.
+- Trusting a character because you are friends with the player who is playing that character.
+- Not fighting a character because you are friends with the player who is playing that character.
+- Ignoring your objective to kill a character because your character and theirs became friends in a previous round.
+
+#### Metagrudging Examples
+These are all examples of things that are prohibited.
+
+- Not giving a character additional access or a job because you are mad at or don't like the player who is playing that character.
+- Not trusting a character because you are mad at or don't like the player who is playing that character.
+- Starting a fight with a character because of something that they did in a previous round.
+- Starting a fight with a character because of a major event that happened in a previous round.
+- Starting a fight with a character because they killed you while you were playing a different character.
+- Targeting or harassing a character based on anything which that character did in a previous round.
+- Targeting or harassing a character based on anything which the character's player did while not playing the character.
+
+
+## Explicitly Not Metagaming
+
+- Protecting high value crew items (will be labeled as such), such as the nuke disk, with the understanding that a bad actor may attempt to steal or use them.
+- Remembering the general events of previous rounds (shifts) up to the extent that you do not metagrudge or metafriend any other player or character, remembering that you survived a violent shooting in the medbay is acceptable for example, stating who the shooter was is not. Avoid making remarks about specific characters, such as calling out someone who was an antagonist in a prior round.
+- The fact that antagonists exist and may be present on or off the station in any form.
+- Knowledge of a characters typical appearance.
+- Using knowledge of a characters typical appearance including your own for a disguise, such as a nuclear operative disguising as themselves as crew.
+- Knowing that enemies may have concealed items that may have function that are not immediately apparent.
+</Document>

--- a/Resources/ServerInfo/_Ronstation/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
+++ b/Resources/ServerInfo/_Ronstation/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
@@ -10,8 +10,18 @@ The knowledge that a round will end is out of character information. Knowledge t
 ### Knowledge from past lives
 Except when otherwise specified, you cannot use any information gained in a past life (i.e., different character) in the same round.
 For example, if you were killed by an antagonist, you cannot warn the crew of said antagonist when you respawn as a mothroach.
-In the cases of being cloned post-mortem, having your brain be put into a cyborg via a MMI, or splitting into nymphs as a diona, these characters are allowed to retain memories of events prior to the death of their original body, but must follow new life rules regarding death (see 'Knowledge gained while crit, knowledge lost upon death').
-For example, if you were killed by an antagonist, your body was found and your brain was placed in a borg, you can recall what happened prior to your original death, except for details of what lead to your death.
+In the cases of being cloned post-mortem, having your brain be put into a cyborg via a MMI, or splitting into nymphs as a diona, these characters are allowed to retain memories of their original body, but must follow new life rules regarding death (see 'Knowledge gained while crit, knowledge lost upon death').
+
+### Knowledge gained while in crit, knowledge lost upon death (New Life Rule)
+Being unconscious (critically injured, asleep or dead) prevents your character from remembering anything that happened to or around them while unconscious. If brought out of the critical state to the alive state, you may remember what caused you to enter critical state. Entering the dead state causes your character to forget the direct cause of their death. This includes who killed them, how they were killed, and any actions or events that immediately led to their death. If revived, your character may know that they died, but not the killer’s identity, their method, or other incriminating details.
+
+#### New Life Rule (NLR) Examples
+These are examples of things that are prohibited.
+- A character was killed by an antag and brought to medbay, where they were revived. The victim immediately divulges the name of the person who killed them.
+- A diona character is lying dead. They decide to use the unique ability of their species to split into nymphs. The nymph/reformed diona tells another character what lead to their death.
+- Someone was gibbed in a shuttle ramming incident, and their brain was placed in an MMI. Either as the MMI or a borg, they comment about the shuttle speeding towards them before they died.
+- A passenger drinks themself to the point of having fatal alcohol poisoning. Doctors see the amount of poison damage and opt to clone the individual. When they reform as a clone, the passenger comments that they do not regret overdrinking, without first being told how they died.
+- A cargo tech is put into crit by spacing. A thief comes to their rescue, but steals the cargo tech's PDA in the process to fulfil an objective. Once the victim is revived, they immediately call out the thief for stealing their PDA.
 
 ### Knowledge that the round will end (and your character will, ergo, cease to exist)
 Your character will, or should, know that their current shift on Space Station 14 will end and that they will return to Centcomm. They do not know that this represents the effective end of their existence from the perspective of their player.
@@ -20,10 +30,7 @@ You cannot prepare for end-of-round griefing (EORG) or perform other actions tha
 ### Knowledge gained via LOOC
 You cannot use any knowledge gained via LOOC chat that is not in the context of assisting a player with controls, game mechanics, or being made to feel welcome. No in character information should be shared via LOOC, and no actions should be taken or altered because of LOOC or OOC chats.
 
-### Knowledge gained while in crit, knowledge lost upon death
-Being in the critically injured state or otherwise unconscious (includes sleeping) prevents your character from remembering anything that happened to or around them while unconscious. If brought out of the critical state to the alive state, you may remember what caused you to enter critical state. Entering the dead state causes your character to forget all events related to their death (if you can tie it to how you died, do not remember it). If revived, placed in a MMI, or in the case of Diona, splitting, the character is aware of the fact that they have died but not how.
-
-## Do Not Metafriend or Metagrudge
+### Do Not Metafriend or Metagrudge
 Giving a person or character preferential treatment based on the events of a previous round is considered metafriending. Treating a person or character negatively based on the events of a previous round is considered metagrudging.
 
 #### Metafriending Examples


### PR DESCRIPTION
A revision of RP rule 4 making what is commonly referred to as "new life rule" (NLR) formally enforceable under LRP.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The PR changes one line of text in roleplay rule 4, which originally says "MRP Amendment", and replaces it with "Knowledge gained in crit, knowledge lost upon death", removing the MRP language entirely.

## Why / Balance
We have always expected players to commit to NLR, but never adjusted the rules to support it until now. Stealing an item off a player as traitor (which may require killing them) is very difficult to get away with if the person you killed can just turn around and tattle on you when revived.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: New life rule is no longer an MRP amendment, and is enforced under LRP.

