### PR TITLE
Buff the Negotiator's fire rate

### DIFF
--- a/Resources/Prototypes/_Ronstation/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Ronstation/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -7,7 +7,7 @@
   - type: Sprite
     sprite: _Ronstation/Objects/Weapons/Guns/Pistols/negotiator.rsi
   - type: Gun
-    fireRate: 1.7
+    fireRate: 3
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto


### PR DESCRIPTION
## About the PR
Increases the fire rate of the Head of Security's Negotiator from 1.7 to 3 shots per second.
Increasing damage per second from 59.5 to 105 piercing damage per second.

## Why / Balance
Determined through discussions that it needed this change.

## Technical details
the YAML oneliner.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: arenaconspiracy
- tweak: The Negotiator handgun had it's fire rate increased from 1.7 to 3 shots per second.