### PR TITLE
Saltern-II BSO update

### DIFF
--- a/Resources/Maps/Ronstation/saltern-2.yml
+++ b/Resources/Maps/Ronstation/saltern-2.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 08/31/2025 19:45:56
-  entityCount: 17006
+  time: 09/02/2025 16:55:47
+  entityCount: 17008
 maps:
 - 1
 grids:
@@ -8778,7 +8778,7 @@ entities:
   - uid: 49
     components:
     - type: MetaData
-      name: blueshield office
+      name: Blueshield Officer
     - type: Transform
       pos: -7.5,28.5
       parent: 2
@@ -10087,7 +10087,7 @@ entities:
       pos: -33.5,9.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -18345.494
+      secondsUntilStateChange: -18434.361
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10221,7 +10221,7 @@ entities:
       pos: 13.5,-9.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -210996.38
+      secondsUntilStateChange: -211085.25
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -76204,6 +76204,20 @@ entities:
     - type: Transform
       pos: 4.5,21.5
       parent: 2
+- proto: HolopadCommandBridgeLongRange
+  entities:
+  - uid: 12975
+    components:
+    - type: Transform
+      pos: 3.5,33.5
+      parent: 2
+- proto: HolopadCommandBso
+  entities:
+  - uid: 12954
+    components:
+    - type: Transform
+      pos: -10.5,28.5
+      parent: 2
 - proto: HolopadCommandCaptain
   entities:
   - uid: 11221
@@ -76560,7 +76574,7 @@ entities:
       pos: 16.5,-40.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -86375.24
+      secondsUntilStateChange: -86464.11
       state: Opening
 - proto: HospitalCurtainsOpen
   entities:


### PR DESCRIPTION
## About the PR
Redoes the BSO room and nukes paper printers on Saltern-II

## Why / Balance
BSO overhaul necessitates changes to the rooms & paper printers are undesirable.

## Media
<img width="4640" height="4000" alt="Saltern2-0" src="https://github.com/user-attachments/assets/041f8d42-371f-4ce0-a6b2-06637619ccfd" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.