### PR TITLE
Make butterflies Zombie Immune

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -839,6 +839,7 @@
       behaviors:
       - !type:GibBehavior
         recursive: false
+  - type: ZombieImmune
 
 - type: entity
   name: cow

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -839,7 +839,7 @@
       behaviors:
       - !type:GibBehavior
         recursive: false
-  - type: ZombieImmune
+  - type: ZombieImmune # Ronstation - modification
 
 - type: entity
   name: cow


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes butterflies immune to romerol infection.

## Why / Balance
Similar creatures either cannot infect you or are themselves immune to romerol. The closest comparison was the bee mob, which is zombie immune, so I gave butterflies zombie immune to fix what I presume is an oversight.

## Technical details
Adds a component to MobButterfly in animals.yml.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking Changes
N/A

**Changelog**
:cl:
- tweak: Butterflies can no longer be infected with romerol or become romerol zombies
