### PR TITLE
Forcefully replace Damageable component when animate spell is used

### DIFF
--- a/Resources/Prototypes/Magic/animate_spell.yml
+++ b/Resources/Prototypes/Magic/animate_spell.yml
@@ -25,9 +25,6 @@
       - TegGenerator
       - TegCirculator
       - XenoArtifact
-      # start of modifications
-      - ResistLocker # Ronstation edit - Lockers have very janky interactions with this spell. Never forget the Locker Tide
-      # end of modifications
     event: !type:ChangeComponentsSpellEvent
       toAdd:
       - type: Animate


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made animation spell forcibly replace Damageable component instead of just adding it if it doesn't exist

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Seems like an upstream bug? Maybe? Idk

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak:  Made animation spell force entities to use ManifestedSpirit damageable component
