### PR TITLE
Banana Touch > Cluwne's Curse

### DIFF
--- a/Content.Server/Magic/MagicSystem.cs
+++ b/Content.Server/Magic/MagicSystem.cs
@@ -1,4 +1,6 @@
+// Modified by Ronstation contributor(s), therefore this file is licensed as MIT sublicensed with AGPL-v3.0.
 using Content.Server.Chat.Systems;
+using Content.Server.Clothing.Systems; // Modification
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Shared.Magic;
@@ -15,6 +17,7 @@ public sealed class MagicSystem : SharedMagicSystem
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
+    [Dependency] private readonly OutfitSystem _outfitSystem = default!; // Modification
 
     private static readonly ProtoId<TagPrototype> InvalidForSurvivorAntagTag = "InvalidForSurvivorAntag";
 
@@ -51,4 +54,13 @@ public sealed class MagicSystem : SharedMagicSystem
         if (!_gameTicker.IsGameRuleActive<SurvivorRuleComponent>())
             _gameTicker.StartGameRule(survivorRule);
     }
+    // Start of modifications
+    public override void OnTransformSpell(TransformSpellEvent ev)
+    {
+        base.OnTransformSpell(ev);
+
+        if (!ev.Cancelled)
+            _outfitSystem.SetOutfit(ev.Target, ev.Loadout);
+    }
+    // End of modifications
 }

--- a/Content.Shared/_Ronstation/Magic/Components/WizardTransformationComponent.cs
+++ b/Content.Shared/_Ronstation/Magic/Components/WizardTransformationComponent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Magic.Components;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(SharedMagicSystem))]
+public sealed partial class WizardTransformationComponent : Component;

--- a/Content.Shared/_Ronstation/Magic/Events/CellularSmiteSpellEvent.cs
+++ b/Content.Shared/_Ronstation/Magic/Events/CellularSmiteSpellEvent.cs
@@ -9,5 +9,5 @@ public sealed partial class CellularSmiteSpellEvent : EntityTargetActionEvent
     // Damage that the smite spell will do.
     //</summary>
     [DataField]
-    public DamageSpecifier smiteDamage = new();
+    public DamageSpecifier SmiteDamage = new();
 }

--- a/Content.Shared/_Ronstation/Magic/Events/TransformSpellEvent.cs
+++ b/Content.Shared/_Ronstation/Magic/Events/TransformSpellEvent.cs
@@ -1,0 +1,32 @@
+using Content.Shared.Actions;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Magic.Events;
+
+public sealed partial class TransformSpellEvent : EntityTargetActionEvent
+{
+    /// <summary>
+    /// Components added or removed from the target
+    /// </summary>
+    [DataField]
+    [AlwaysPushInheritance]
+    public ComponentRegistry ToAdd = new();
+
+    [DataField]
+    [AlwaysPushInheritance]
+    public HashSet<string> ToRemove = new();
+
+    /// <summary>
+    /// Outfit forced onto the target
+    /// </summary>
+    [DataField]
+    public string Loadout;
+
+    /// <summary>
+    /// Whether our event was cancelled or not by invalid targeting etc
+    /// </summary>
+    public bool Cancelled = false;
+
+    [DataField]
+    public string FailureMessage = "spell-target-immune-transformed";
+}

--- a/Resources/Locale/en-US/_Ronstation/magic/magic.ftl
+++ b/Resources/Locale/en-US/_Ronstation/magic/magic.ftl
@@ -1,1 +1,4 @@
 spell-target-immune = A higher power protects them from your spell!
+spell-target-immune-transformed = They're already transformed.
+
+action-speech-spell-clown = HONK!

--- a/Resources/Locale/en-US/_Ronstation/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/_Ronstation/store/spellbook-catalog.ftl
@@ -1,0 +1,2 @@
+spellbook-clown-name = Banana Touch
+spellbook-clown-desc = Curses the target to be a clown. Use it on people you don't like, but for whom death is a bit too merciful. Requires Wizard Robe & Hat.

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -41,7 +41,7 @@
 #   - !type:ListingLimitedStockCondition
 #     stock: 1
 
-# Ronstation - Smite fucks you up real bad, but doesn't remove you from the round.
+# Ronstation - Modified spells.
 - type: listing
   id: SpellbookCellularSmite
   name: spellbook-cellular-smite-name
@@ -54,13 +54,12 @@
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 1
-# end of modifications
 
 - type: listing
-  id: SpellbookCluwne
-  name: spellbook-cluwne-name
-  description: spellbook-cluwne-desc
-  productAction: ActionCluwne
+  id: SpellbookClown
+  name: spellbook-clown-name
+  description: spellbook-clown-desc
+  productAction: ActionClown
   cost:
     WizCoin: 3
   categories:
@@ -68,6 +67,20 @@
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 1
+# end of modifications
+
+# - type: listing
+#   id: SpellbookCluwne
+#   name: spellbook-cluwne-name
+#   description: spellbook-cluwne-desc
+#   productAction: ActionCluwne
+#   cost:
+#     WizCoin: 3
+#   categories:
+#   - SpellbookOffensive
+#   conditions:
+#   - !type:ListingLimitedStockCondition
+#     stock: 1
 
 - type: listing
   id: SpellbookSlip

--- a/Resources/Prototypes/Magic/touch_spells.yml
+++ b/Resources/Prototypes/Magic/touch_spells.yml
@@ -97,6 +97,33 @@
     sentence: action-speech-spell-cluwne
   - type: Magic
     requiresClothes: true
+# Start of modifications
+- type: entity
+  parent: BaseSmiteAction
+  id: ActionClown
+  name: Banana Touch
+  description: Turns someone into a Clown!
+  components:
+  - type: Action
+    useDelay: 120
+    sound: !type:SoundPathSpecifier
+      path: /Audio/Items/bikehorn.ogg
+    icon:
+      sprite: Clothing/Mask/clown.rsi
+      state: icon
+  - type: EntityTargetAction
+    event: !type:TransformSpellEvent
+      toAdd:
+      - type: Clumsy
+        clumsyDefib: false
+      - type: WizardTransformation
+      loadout: ClownGear
+      failureMessage: "They're already clown enough!"
+  - type: SpeakOnAction
+    sentence: action-speech-spell-clown
+  - type: Magic
+    requiresClothes: true
+# End of modifications
 
 - type: entity
   parent: BaseSmiteAction


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Banana Touch has fully replaced Cluwne's Curse as a spell in the wizard's spellbook.

## Why / Balance
Getting cluwned is a roundabout way of round removing someone and it sucks. Cluwning has become the go-to for wizards that want to round remove as many people as possible lately, and given that it is as uninteresting as ye olde smite, I'd like to see it gone. We now have Banana Touch, turning them into a True Clown instead (IE with the Clumsy trait). This is potentially still quite a strong curse as there is currently no way to remove curses, so you could end up crippling a security force over time or forcing the captain to put their laser pistol away, but hey, at least they still get to play the game.

## Technical details
Made a new spell event, TransformSpellEvent, taking heavy inspiration from how https://github.com/ss14-harmony/ss14-harmony/pull/524 was worked on. This event can both add or remove components and apply a new outfit to the target. Could make for some interesting spells in the future beyond just Banana Touch if we ever do a proper Ronstation Spell Pack. Also added a WizardTransformationComponent as a stop-gap to prevent you from applying one of these spells multiple times. With Banana Touch, this wouldn't necessarily result in much, but future spells might be more abusable without this restriction. The component could be worked on more in the future to allow for multiple Transformations to apply at once without applying existing ones multiple times, but that felt outside the scope of this project. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/7f08f4d7-469e-46a5-a18f-153e08cf4a43
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Banana Touch has been added to the Wizard's spellbook, replacing Cluwne's Curse. The target of this spell is cursed to be a True Clown, with Clumsy Trait and (removable) clown outfit to match.
- remove: Cluwne's Curse has been removed from the wizard's spellbook.

