### PR TITLE
Clamp Vulp colors further

### DIFF
--- a/Resources/Prototypes/Species/skin_colorations.yml
+++ b/Resources/Prototypes/Species/skin_colorations.yml
@@ -1,3 +1,4 @@
+# Contains modifications made by Ronstation contributors, therefore this file is subject to MIT sublicensed with AGPL v3.0.
 - type: skinColoration
   id: Hues
   strategy: !type:ClampedHsvColoration
@@ -22,7 +23,7 @@
 
 - type: skinColoration
   id: VulpkaninColors
-  strategy: !type:ClampedHsvColoration
-    hue: [0.02, 0.12]
-    saturation: [0, 0.8]
-    value: [0.2, 0.78]
+  strategy: !type:ClampedHsvColoration # Ronstation - modifications
+    hue: [0.02, 0.12] # Ronstation - modifications
+    saturation: [0, 0.8] # Ronstation - modifications
+    value: [0.2, 0.78] # Ronstation - modifications

--- a/Resources/Prototypes/Species/skin_colorations.yml
+++ b/Resources/Prototypes/Species/skin_colorations.yml
@@ -22,6 +22,7 @@
 
 - type: skinColoration
   id: VulpkaninColors
-  strategy: !type:ClampedHslColoration
-    saturation: [0.0, 0.60]
-    lightness: [0.2, 0.9]
+  strategy: !type:ClampedHsvColoration
+    hue: [0.02, 0.12]
+    saturation: [0, 0.8]
+    value: [0.2, 0.78]

--- a/Resources/Prototypes/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Species/vulpkanin.yml
@@ -16,8 +16,8 @@
   id: MobVulpkaninSprites
   sprites:
     Head: MobVulpkaninHead
-    Hair: MobHumanoidAnyMarking
-    FacialHair: MobHumanoidAnyMarking
+    Hair: MobVulpMarkingFollowSkin
+    FacialHair: MobVulpMarkingFollowSkin
     Snout: MobHumanoidAnyMarking
     SnoutCover: MobHumanoidAnyMarking
     UndergarmentTop: MobHumanoidAnyMarking
@@ -76,6 +76,11 @@
     Legs:
       points: 6
       required: false
+
+- type: humanoidBaseSprite
+  id: MobVulpMarkingFollowSkin
+  markingsMatchSkin: true
+  layerAlpha: 0.9
 
 - type: humanoidBaseSprite
   id: MobVulpkaninEyes

--- a/Resources/Prototypes/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Species/vulpkanin.yml
@@ -1,3 +1,4 @@
+# Contains modifications made by Ronstation contributors, therefore this file is subject to MIT sublicensed with AGPL v3.0.
 - type: species
   id: Vulpkanin
   name: species-name-vulpkanin
@@ -16,8 +17,8 @@
   id: MobVulpkaninSprites
   sprites:
     Head: MobVulpkaninHead
-    Hair: MobVulpMarkingFollowSkin
-    FacialHair: MobVulpMarkingFollowSkin
+    Hair: MobVulpMarkingFollowSkin # Ronstation - modification
+    FacialHair: MobVulpMarkingFollowSkin # Ronstation - modification
     Snout: MobHumanoidAnyMarking
     SnoutCover: MobHumanoidAnyMarking
     UndergarmentTop: MobHumanoidAnyMarking
@@ -77,10 +78,12 @@
       points: 6
       required: false
 
+# start of modifications
 - type: humanoidBaseSprite
   id: MobVulpMarkingFollowSkin
   markingsMatchSkin: true
   layerAlpha: 0.9
+# end of modifications
 
 - type: humanoidBaseSprite
   id: MobVulpkaninEyes


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Vulp colors have been clamped further and hair colors have been set to follow skin color.

## Why / Balance
They were requested changes to make some more comfortable with vulpakanin.
 
## Technical details
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Vulpakanin colors have been clamped significantly, and hair color for vulpakanin now follows skin color.


