### PR TITLE
Update the energy shotgun's contraband marking

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -836,6 +836,8 @@
   - type: Appearance
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/energy_shotgun.rsi
+  - type: Contraband # Ronstation
+    allowedDepartments: [Security] # Ronstation
   - type: Gun
     fireRate: 2
     soundGunshot:


### PR DESCRIPTION
## About the PR
Changes the energy shotgun allow department tag from Command to Security.

## Why / Balance
The Warden is not part of command, and a powergaming acting captain argued that they're allowed to have it actually because the game says so.

## Technical details
YAML 2 liner.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: The Warden's energy shotgun is now marked as Security contraband instead of Command