### PR TITLE
Buff the Gendarme

### DIFF
--- a/Resources/Prototypes/_Ronstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Ronstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -45,7 +45,7 @@
     maxCharge: 1200
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 25
+    autoRechargeRate: 40
   - type: ProjectileBatteryAmmoProvider
     proto: BulletLaserGendarme
     fireCost: 200

--- a/Resources/Prototypes/_Ronstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Ronstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -21,7 +21,7 @@
         mask:
         - Opaque
   - type: StaminaDamageOnCollide
-    damage: 22 # 11 less than a normal disabler
+    damage: 33
 
 - type: entity
   id: BulletLaserGendarme
@@ -49,4 +49,4 @@
       types:
         Heat: 20
   - type: StaminaDamageOnCollide
-    damage: 15
+    damage: 20


### PR DESCRIPTION
## About the PR
Increases the Gendarme self recharging rate from 25 to 40 watts per second.
Increases the Gendarme nonlethal projectile stamina damage from 22 to 33.
Increases the Gendarme lethal projectile stamina damage from 15 to 22.

## Why / Balance
The Gendarme is currently a surprisingly underwhelming combat utility, despite all the boons it gets. And it's nonlethal fire mode is worthless when it takes longer to stamcrit than a disabler. These buffs should give the Gendarme more weight in a large scale firefight, and encourage use of the nonlethal mode _at all_ when it's needed.

## Technical details
YAML warrior.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: The Gendarme has had it's recharge rate and stamina damage improved considerably.