### PR TITLE
Fix telescopic shield contraband marker

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -570,6 +570,7 @@
           visible: false
           map: [ "shield" ]
     - type: Contraband # Ronstation
+      allowedDepartments: [Security] # Ronstation (seriously?)
       allowedJobs: [BlueshieldOfficer] # Ronstation
     - type: Item
       size: Small


### PR DESCRIPTION
## About the PR
Adds Security to the allowed department list of the telescopic shield.

## Why / Balance
I added BSO allowed job assuming that it had security allowed job to start with. It didn't.

## Technical details
yamlowy wojak

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: The telescopic shield is now correctly marked as security contraband.